### PR TITLE
[YS-304] refactor: 공고 상세 조회 시, 반환값으로 alarmAgree 필드 추가

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCase.kt
@@ -38,7 +38,8 @@ class GetExperimentPostDetailUseCase(
         val content: String,
         val imageList: List<String>,
         val isAuthor: Boolean,
-        val isUploaderActive: Boolean
+        val isUploaderActive: Boolean,
+        val alarmAgree: Boolean
     ) {
         data class Summary(
             val startDate: LocalDate?,
@@ -91,7 +92,8 @@ fun ExperimentPost.toExperimentPostDetail(memberId: String?): GetExperimentPostD
         content = this.content,
         imageList = this.images.map { it.imageUrl },
         isAuthor = this.member.id == memberId,
-        isUploaderActive = this.member.deletedAt == null
+        isUploaderActive = this.member.deletedAt == null,
+        alarmAgree = this.alarmAgree
     )
 }
 

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/experiment/ExperimentPostDetailResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/experiment/ExperimentPostDetailResponse.kt
@@ -48,7 +48,10 @@ data class ExperimentPostDetailResponse(
     val imageList: List<String>,
 
     @Schema(description = "글쓴이 여부", example = "true")
-    val isAuthor: Boolean
+    val isAuthor: Boolean,
+
+    @Schema(description = "알림 동의 여부", example = "true")
+    val alarmAgree: Boolean
 ) {
     @Schema(description = "실험 공고 요약 정보")
     data class SummaryResponse(

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
@@ -176,7 +176,8 @@ object ExperimentPostMapper {
             content = response.experimentPostDetail.content,
             imageList = response.experimentPostDetail.imageList,
             isAuthor = response.experimentPostDetail.isAuthor,
-            isUploaderActive = response.experimentPostDetail.isUploaderActive
+            isUploaderActive = response.experimentPostDetail.isUploaderActive,
+            alarmAgree = response.experimentPostDetail.alarmAgree
         )
     }
 


### PR DESCRIPTION
## 💡 작업 내용
- 프론트엔드의 요청으로 **기존 공고 상세 조회 시 누락되었던 `alarmAgree` 필드값을 추가하여 반환**합니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요
단순한 필드값 추가이기 때문에 **유연하게 핫픽스 처리**하겠습니다.

## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 실험 게시물 상세 정보 응답에 사용자의 알림 수신 동의 여부를 나타내는 새로운 필드가 추가되었습니다.
  - 이 개선을 통해 게시물 관련 알림 설정 상태를 보다 명확하게 확인할 수 있습니다.
  - 업데이트된 응답 정보는 사용자 맞춤 설정에 대한 이해도를 높여 사용자 경험을 향상시킵니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->