### PR TITLE
[YS-306] fix: 공고 수정 시 nullable 필드 및 이미지 생성 버그 수정

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/usecase/experiment/UpdateExperimentPostUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/experiment/UpdateExperimentPostUseCase.kt
@@ -1,6 +1,7 @@
 package com.dobby.backend.application.usecase.experiment
 
 import com.dobby.backend.application.usecase.UseCase
+import com.dobby.backend.domain.IdGenerator
 import com.dobby.backend.domain.exception.*
 import com.dobby.backend.domain.gateway.experiment.ExperimentPostGateway
 import com.dobby.backend.domain.model.experiment.ExperimentPost
@@ -12,7 +13,8 @@ import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import java.time.LocalDate
 
 class UpdateExperimentPostUseCase (
-    private val experimentPostGateway: ExperimentPostGateway
+    private val experimentPostGateway: ExperimentPostGateway,
+    private val idGenerator: IdGenerator
 ) : UseCase<UpdateExperimentPostUseCase.Input, UpdateExperimentPostUseCase.Output> {
     data class Input(
         val experimentPostId: String,
@@ -104,7 +106,8 @@ class UpdateExperimentPostUseCase (
             univName = input.univName,
             region = input.region,
             area = input.area,
-            imageListInfo = input.imageListInfo?.images
+            imageListInfo = input.imageListInfo?.images,
+            idGenerator = idGenerator
         )
         val updatedPost = experimentPostGateway.save(experimentPost)
 

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/experiment/UpdateExperimentPostRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/experiment/UpdateExperimentPostRequest.kt
@@ -17,14 +17,14 @@ data class UpdateExperimentPostRequest (
     val count: Int, // N 회 참여
     val timeRequired: TimeSlot?,
 
-    val leadResearcher: String, // 연구 책임 정보 -> 기본값: 연구자 정보에서 끌어와야 함, 추후에 자유롭게 수정 가능
+    val leadResearcher: String?, // 연구 책임 정보 -> 기본값: 연구자 정보에서 끌어와야 함, 추후에 자유롭게 수정 가능
 
-    val univName: String, // 대학교 이름 -> 기본값: 연구자 정보에서 끌어와야 함, 추후에 자유롭게 수정 가능
-    val region: Region,
-    val area: Area,
+    val univName: String?, // 대학교 이름 -> 기본값: 연구자 정보에서 끌어와야 함, 추후에 자유롭게 수정 가능
+    val region: Region?,
+    val area: Area?,
     val detailedAddress: String?,
 
-    val reward: String,
-    val title: String,
-    val content: String,
+    val reward: String?,
+    val title: String?,
+    val content: String?,
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/experiment/UpdateExperimentPostRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/experiment/UpdateExperimentPostRequest.kt
@@ -24,7 +24,7 @@ data class UpdateExperimentPostRequest (
     val area: Area?,
     val detailedAddress: String?,
 
-    val reward: String?,
-    val title: String?,
-    val content: String?,
+    val reward: String,
+    val title: String,
+    val content: String,
 )


### PR DESCRIPTION
## 💡 작업 내용
- ExperimentPost.update() 메서드 리팩토링
- 비즈니스 규칙에 따라, `matchType = ONLINE` 시, `region` `area` `univName` 이 전부 nullable 하도록 값 수정
- 이미지 생성 시 중복된 ExperimentImage 객체가 생성되는 문제 해결 → TSID로 id 생성 전략 이후 발견된 버그

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- [이전](https://github.com/YAPP-Github/Gradmeet-BE/pull/94)  [PR들](https://github.com/YAPP-Github/Gradmeet-BE/pull/95) 과 마찬가지로 **핫픽스 처리**하겠습니다 :)

## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 실험 포스트 업데이트 시 리드 연구원, 대학명, 지역, 분야 등의 항목이 선택적으로 입력될 수 있어 더욱 유연한 정보 제공이 가능합니다.
- **개선 사항**
  - 이미지 처리 로직이 개선되어, 새로운 이미지에 고유 아이디가 자동 할당되어 중복 없이 효과적으로 관리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-306