### PR TITLE
[YS-310] feat: 실험 공고 수정 시, 입력 자동완성 지원을 위한 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/service/ExperimentPostService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/ExperimentPostService.kt
@@ -28,6 +28,7 @@ class ExperimentPostService(
     private val getExperimentPostApplyMethodUseCase: GetExperimentPostApplyMethodUseCase,
     private val generateExperimentPostPreSignedUrlUseCase: GenerateExperimentPostPreSignedUrlUseCase,
     private val updateExpiredExperimentPostUseCase: UpdateExpiredExperimentPostUseCase,
+    private val getExperimentPostForUpdateUseCase: GetExperimentPostDetailForUpdateUseCase,
     private val deleteExperimentPostUseCase: DeleteExperimentPostUseCase,
     private val updateExperimentPostRecruitStatusUseCase: UpdateExperimentPostRecruitStatusUseCase,
     private val getExperimentPostTotalCountByCustomFilterUseCase: GetExperimentPostTotalCountByCustomFilterUseCase,
@@ -45,6 +46,11 @@ class ExperimentPostService(
     @Transactional
     fun updateExperimentPost(input: UpdateExperimentPostUseCase.Input): UpdateExperimentPostUseCase.Output{
         return updateExperimentPostUseCase.execute(input)
+    }
+
+    @Transactional
+    fun getExperimentPostDetailForUpdate(input: GetExperimentPostDetailForUpdateUseCase.Input): GetExperimentPostDetailForUpdateUseCase.Output {
+        return getExperimentPostForUpdateUseCase.execute(input)
     }
 
     @Transactional

--- a/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailForUpdateUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailForUpdateUseCase.kt
@@ -1,0 +1,128 @@
+package com.dobby.backend.application.usecase.experiment
+
+import com.dobby.backend.application.usecase.UseCase
+import com.dobby.backend.domain.exception.ExperimentPostNotFoundException
+import com.dobby.backend.domain.gateway.experiment.ExperimentPostGateway
+import com.dobby.backend.domain.model.experiment.ExperimentPost
+import com.dobby.backend.domain.model.experiment.TargetGroup
+import com.dobby.backend.infrastructure.database.entity.enums.MatchType
+import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
+import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
+import java.time.LocalDate
+
+class GetExperimentPostDetailForUpdateUseCase(
+    private val experimentPostGateway: ExperimentPostGateway
+) : UseCase<GetExperimentPostDetailForUpdateUseCase.Input, GetExperimentPostDetailForUpdateUseCase.Output> {
+
+    data class Input(
+        val experimentPostId: String,
+        val memberId: String
+    )
+
+    data class Output(
+        val experimentPostDetail: ExperimentPostDetailForUpdate
+    )
+
+    data class ExperimentPostDetailForUpdate(
+        val experimentPostId: String,
+        val title: String,
+        val uploadDate: LocalDate,
+        val uploaderName: String,
+        val views: Int,
+        val recruitStatus: Boolean,
+        val summary: Summary,
+        val targetGroup: TargetGroup,
+        val address: Address,
+        val content: String,
+        val imageList: List<String>,
+        val isAuthor: Boolean,
+        val isUploaderActive: Boolean,
+        val alarmAgree: Boolean
+    ) {
+        data class Summary(
+            val startDate: LocalDate?,
+            val endDate: LocalDate?,
+            val leadResearcher: String,
+            val matchType: MatchType,
+            val reward: String,
+            val count: Int?,
+            val timeRequired: TimeSlot?
+        )
+
+        data class TargetGroup(
+            val startAge: Int?,
+            val endAge: Int?,
+            val genderType: GenderType,
+            val otherCondition: String?
+        )
+
+        data class Address(
+            val univName: String?,
+            val region: Region?,
+            val area: Area?,
+            val detailedAddress: String?
+        )
+    }
+
+    override fun execute(input: Input): Output {
+        val post = experimentPostGateway.findExperimentPostByMemberIdAndPostId(
+            memberId = input.memberId,
+            postId = input.experimentPostId
+        ) ?: throw ExperimentPostNotFoundException
+
+        return Output(
+            experimentPostDetail = post.toExperimentPostDetailForUpdate(input.memberId)
+        )
+    }
+}
+
+fun ExperimentPost.toExperimentPostDetailForUpdate(memberId: String): GetExperimentPostDetailForUpdateUseCase.ExperimentPostDetailForUpdate {
+    return GetExperimentPostDetailForUpdateUseCase.ExperimentPostDetailForUpdate(
+        experimentPostId = this.id,
+        title = this.title,
+        uploadDate = this.createdAt.toLocalDate(),
+        uploaderName = this.member.name,
+        views = this.views,
+        recruitStatus = this.recruitStatus,
+        summary = this.toSummaryForUpdate(),
+        targetGroup = this.targetGroup.toTargetGroupForUpdate(),
+        address = this.toAddressForUpdate(),
+        content = this.content,
+        imageList = this.images.map { it.imageUrl },
+        isAuthor = this.member.id == memberId,
+        isUploaderActive = this.member.deletedAt == null,
+        alarmAgree = this.alarmAgree
+    )
+}
+
+fun ExperimentPost.toSummaryForUpdate(): GetExperimentPostDetailForUpdateUseCase.ExperimentPostDetailForUpdate.Summary {
+    return GetExperimentPostDetailForUpdateUseCase.ExperimentPostDetailForUpdate.Summary(
+        startDate = this.startDate,
+        endDate = this.endDate,
+        leadResearcher = this.leadResearcher,
+        matchType = this.matchType,
+        reward = this.reward,
+        count = this.count,
+        timeRequired = this.timeRequired
+    )
+}
+
+fun TargetGroup.toTargetGroupForUpdate(): GetExperimentPostDetailForUpdateUseCase.ExperimentPostDetailForUpdate.TargetGroup {
+    return GetExperimentPostDetailForUpdateUseCase.ExperimentPostDetailForUpdate.TargetGroup(
+        startAge = this.startAge,
+        endAge = this.endAge,
+        genderType = this.genderType,
+        otherCondition = this.otherCondition
+    )
+}
+
+fun ExperimentPost.toAddressForUpdate(): GetExperimentPostDetailForUpdateUseCase.ExperimentPostDetailForUpdate.Address {
+    return GetExperimentPostDetailForUpdateUseCase.ExperimentPostDetailForUpdate.Address(
+        univName = this.univName,
+        region = this.region,
+        area = this.area,
+        detailedAddress = this.detailedAddress
+    )
+}

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/ExperimentPostController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/ExperimentPostController.kt
@@ -99,7 +99,7 @@ class ExperimentPostController (
     ): ExperimentPostDetailResponse {
         val input = ExperimentPostMapper.toGetExperimentPostDetailForUpdateUseCaseInput(postId)
         val output = experimentPostService.getExperimentPostDetailForUpdate(input)
-        return ExperimentPostMapper.toGetExperimentPostDetailForUpdateUseCase(output)
+        return ExperimentPostMapper.toGetExperimentPostDetailForUpdateResponse(output)
     }
 
     @PreAuthorize("hasRole('RESEARCHER')")

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/ExperimentPostController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/ExperimentPostController.kt
@@ -89,6 +89,20 @@ class ExperimentPostController (
     }
 
     @PreAuthorize("hasRole('RESEARCHER')")
+    @GetMapping("/{postId}/edit")
+    @Operation(
+        summary = "공고 수정 시 기존 내용 조회 API",
+        description = "연구자가 공고를 수정할 때 기존 공고 내용을 불러옵니다."
+    )
+    fun getExperimentPostDetailForUpdate(
+        @PathVariable postId: String
+    ): ExperimentPostDetailResponse {
+        val input = ExperimentPostMapper.toGetExperimentPostDetailForUpdateUseCaseInput(postId)
+        val output = experimentPostService.getExperimentPostDetailForUpdate(input)
+        return ExperimentPostMapper.toGetExperimentPostDetailForUpdateUseCase(output)
+    }
+
+    @PreAuthorize("hasRole('RESEARCHER')")
     @PostMapping("/image-upload-request")
     @Operation(
         summary = "공고 사진 S3 Presigned Url 요청",

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
@@ -161,7 +161,7 @@ object ExperimentPostMapper {
         )
     }
 
-    fun toGetExperimentPostDetailForUpdateUseCase(response: GetExperimentPostDetailForUpdateUseCase.Output): ExperimentPostDetailResponse {
+    fun toGetExperimentPostDetailForUpdateResponse(response: GetExperimentPostDetailForUpdateUseCase.Output): ExperimentPostDetailResponse {
         return ExperimentPostDetailResponse(
             experimentPostId = response.experimentPostDetail.experimentPostId,
             title = response.experimentPostDetail.title,

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
@@ -154,6 +154,61 @@ object ExperimentPostMapper {
         )
     }
 
+    fun toGetExperimentPostDetailForUpdateUseCaseInput(experimentPostId: String): GetExperimentPostDetailForUpdateUseCase.Input {
+        return GetExperimentPostDetailForUpdateUseCase.Input(
+            experimentPostId = experimentPostId,
+            memberId = getCurrentMemberId()
+        )
+    }
+
+    fun toGetExperimentPostDetailForUpdateUseCase(response: GetExperimentPostDetailForUpdateUseCase.Output): ExperimentPostDetailResponse {
+        return ExperimentPostDetailResponse(
+            experimentPostId = response.experimentPostDetail.experimentPostId,
+            title = response.experimentPostDetail.title,
+            uploadDate = response.experimentPostDetail.uploadDate,
+            uploaderName = response.experimentPostDetail.uploaderName,
+            views = response.experimentPostDetail.views,
+            recruitStatus = response.experimentPostDetail.recruitStatus,
+            summary = response.experimentPostDetail.summary.toResponse(),
+            targetGroup = response.experimentPostDetail.targetGroup.toResponse(),
+            address = response.experimentPostDetail.address.toResponse(),
+            content = response.experimentPostDetail.content,
+            imageList = response.experimentPostDetail.imageList,
+            isAuthor = response.experimentPostDetail.isAuthor,
+            isUploaderActive = response.experimentPostDetail.isUploaderActive,
+            alarmAgree = response.experimentPostDetail.alarmAgree
+        )
+    }
+
+    private fun GetExperimentPostDetailForUpdateUseCase.ExperimentPostDetailForUpdate.Summary.toResponse(): ExperimentPostDetailResponse.SummaryResponse {
+        return ExperimentPostDetailResponse.SummaryResponse(
+            startDate = this.startDate,
+            endDate = this.endDate,
+            leadResearcher = this.leadResearcher,
+            matchType = this.matchType,
+            reward = this.reward,
+            count = this.count,
+            timeRequired = this.timeRequired
+        )
+    }
+
+    private fun GetExperimentPostDetailForUpdateUseCase.ExperimentPostDetailForUpdate.TargetGroup.toResponse(): ExperimentPostDetailResponse.TargetGroupResponse {
+        return ExperimentPostDetailResponse.TargetGroupResponse(
+            startAge = this.startAge,
+            endAge = this.endAge,
+            genderType = this.genderType,
+            otherCondition = this.otherCondition
+        )
+    }
+
+    private fun GetExperimentPostDetailForUpdateUseCase.ExperimentPostDetailForUpdate.Address.toResponse(): ExperimentPostDetailResponse.AddressResponse {
+        return ExperimentPostDetailResponse.AddressResponse(
+            univName = this.univName,
+            region = this.region,
+            area = this.area,
+            detailedAddress = this.detailedAddress
+        )
+    }
 
     fun toGetExperimentPostDetailUseCaseInput(experimentPostId: String): GetExperimentPostDetailUseCase.Input {
         return GetExperimentPostDetailUseCase.Input(

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailForUpdateUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailForUpdateUseCaseTest.kt
@@ -1,0 +1,119 @@
+package com.dobby.backend.application.usecase.experiment
+
+import com.dobby.backend.domain.exception.ExperimentPostNotFoundException
+import com.dobby.backend.domain.gateway.experiment.ExperimentPostGateway
+import com.dobby.backend.domain.model.experiment.ApplyMethod
+import com.dobby.backend.domain.model.experiment.ExperimentPost
+import com.dobby.backend.domain.model.experiment.TargetGroup
+import com.dobby.backend.domain.model.member.Member
+import com.dobby.backend.infrastructure.database.entity.enums.MatchType
+import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
+import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.member.*
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class GetExperimentPostDetailForUpdateUseCaseTest : BehaviorSpec({
+    val experimentPostGateway = mockk<ExperimentPostGateway>()
+    val getExperimentPostDetailForUpdateUseCase = GetExperimentPostDetailForUpdateUseCase(experimentPostGateway)
+
+    val member = mockk<Member>()
+    every { member.name } returns "임도비"
+    every { member.id } returns "1"
+    every { member.deletedAt } returns null
+
+    val targetGroup = mockk<TargetGroup>()
+    every { targetGroup.id } returns "1"
+    every { targetGroup.startAge } returns 18
+    every { targetGroup.endAge } returns 30
+    every { targetGroup.genderType } returns GenderType.ALL
+    every { targetGroup.otherCondition } returns "특별한 조건 없음"
+
+    val applyMethod = mockk<ApplyMethod>()
+    every { applyMethod.id } returns "1"
+    every { applyMethod.phoneNum } returns "010-1234-5678"
+    every { applyMethod.formUrl } returns "http://apply.com/form"
+    every { applyMethod.content } returns "지원 방법에 대한 상세 설명"
+
+    val experimentPostId = "1"
+    val experimentPost = ExperimentPost(
+        id = experimentPostId,
+        title = "야뿌들의 평균 식사량 체크 테스트",
+        createdAt = LocalDateTime.now(),
+        updatedAt = LocalDateTime.now(),
+        member = member,
+        views = 100,
+        recruitStatus = false,
+        startDate = LocalDate.now(),
+        endDate = LocalDate.now(),
+        leadResearcher = "Lead",
+        matchType = MatchType.ALL,
+        reward = "네이버페이 1000원",
+        count = 10,
+        timeRequired = TimeSlot.ABOUT_1H,
+        targetGroup = targetGroup,
+        applyMethod = applyMethod,
+        region = Region.SEOUL,
+        area = Area.GWANGJINGU,
+        univName = "건국대학교",
+        detailedAddress = "건국대학교 공학관",
+        content = "야뿌들의 한끼 식사량을 체크하는 테스트입니다.",
+        alarmAgree = false,
+        images = mutableListOf()
+    )
+
+    given("유효한 experimentPostId와 작성자 본인인 경우") {
+        every { experimentPostGateway.findExperimentPostByMemberIdAndPostId("1", experimentPostId) } returns experimentPost
+
+        `when`("작성자가 수정용 상세 정보를 요청하면") {
+            val input = GetExperimentPostDetailForUpdateUseCase.Input(
+                experimentPostId = experimentPostId,
+                memberId = member.id
+            )
+            val result = getExperimentPostDetailForUpdateUseCase.execute(input)
+
+            then("업데이트를 위한 상세 정보가 정상적으로 반환된다") {
+                result.experimentPostDetail.title shouldBe experimentPost.title
+                result.experimentPostDetail.isAuthor shouldBe true
+            }
+        }
+    }
+
+    given("유효한 experimentPostId지만 작성자가 아닌 경우") {
+        every { experimentPostGateway.findExperimentPostByMemberIdAndPostId("2", experimentPostId) } returns null
+
+        `when`("다른 사용자가 수정용 상세 정보를 요청하면") {
+            val input = GetExperimentPostDetailForUpdateUseCase.Input(
+                experimentPostId = experimentPostId,
+                memberId = "2" // 작성자와 다른 아이디
+            )
+
+            then("ExperimentPostNotFoundException이 발생한다") {
+                val exception = runCatching { getExperimentPostDetailForUpdateUseCase.execute(input) }.exceptionOrNull()
+                exception shouldBe ExperimentPostNotFoundException
+            }
+        }
+    }
+
+    given("유효하지 않은 experimentPostId가 주어진 경우") {
+        val invalidExperimentPostId = "999"
+        every { experimentPostGateway.findExperimentPostByMemberIdAndPostId("1", invalidExperimentPostId) } returns null
+
+        `when`("수정용 상세 정보를 요청하면") {
+            val input = GetExperimentPostDetailForUpdateUseCase.Input(
+                experimentPostId = invalidExperimentPostId,
+                memberId = member.id
+            )
+
+            then("ExperimentPostNotFoundException이 발생한다") {
+                val exception = runCatching { getExperimentPostDetailForUpdateUseCase.execute(input) }.exceptionOrNull()
+                exception shouldBe ExperimentPostNotFoundException
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 💡 작업 내용
- 실험 공고 수정 시, 입력 자동완성 지원을 위한 조회 API 구현
- 관련 테스트 코드 추가

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- discord 백엔드 채널에서 논의된 사항입니다!


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 연구자 역할을 가진 사용자는 이제 포스트 편집 전 상세 정보를 미리 조회할 수 있습니다.
	- 포스트 업데이트를 위한 전용 엔드포인트가 추가되어, 기존 데이터를 보다 효율적으로 불러올 수 있습니다.

- **테스트**
	- 정상 호출, 권한 오류, 잘못된 식별자 등 다양한 시나리오를 검증하여 기능의 안정성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
