### PR TITLE
[YS-328] feat: 이용 약관 관련 기능 추가

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
@@ -28,7 +28,7 @@ class MemberService(
     fun participantSignup(input: CreateParticipantUseCase.Input): CreateParticipantUseCase.Output {
         val existingMember = memberGateway.findByOauthEmailAndStatus(input.oauthEmail, MemberStatus.ACTIVE)
         if(existingMember != null) throw SignupOauthEmailDuplicateException
-           return createParticipantUseCase.execute(input)
+        return createParticipantUseCase.execute(input)
     }
 
     @Transactional

--- a/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
@@ -26,6 +26,8 @@ class MemberService(
 ) {
     @Transactional
     fun participantSignup(input: CreateParticipantUseCase.Input): CreateParticipantUseCase.Output {
+        val existingMember = memberGateway.findByOauthEmailAndStatus(input.oauthEmail, MemberStatus.ACTIVE)
+        if(existingMember != null) throw SignupOauthEmailDuplicateException
            return createParticipantUseCase.execute(input)
     }
 

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCase.kt
@@ -92,13 +92,6 @@ class CreateParticipantUseCase (
             name = input.name,
         )
 
-        val memberConsent = MemberConsent.newConsent(
-            memberId = member.id,
-            adConsent = input.adConsent,
-            matchConsent = input.matchConsent,
-        )
-        memberConsentGateway.save(memberConsent)
-
         val participant= Participant.newParticipant(
             id = idGenerator.generateId(),
             member = member,
@@ -114,6 +107,13 @@ class CreateParticipantUseCase (
             ),
             matchType = input.matchType
         )
+
+        val memberConsent = MemberConsent.newConsent(
+            memberId = member.id,
+            adConsent = input.adConsent,
+            matchConsent = input.matchConsent,
+        )
+        memberConsentGateway.save(memberConsent)
 
         return participantGateway.save(participant)
     }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCase.kt
@@ -107,6 +107,7 @@ class CreateParticipantUseCase (
             ),
             matchType = input.matchType
         )
+        participantGateway.save(participant)
 
         val memberConsent = MemberConsent.newConsent(
             memberId = member.id,
@@ -115,6 +116,6 @@ class CreateParticipantUseCase (
         )
         memberConsentGateway.save(memberConsent)
 
-        return participantGateway.save(participant)
+        return participant
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCase.kt
@@ -4,7 +4,9 @@ import com.dobby.backend.application.usecase.UseCase
 import com.dobby.backend.domain.IdGenerator
 import com.dobby.backend.domain.gateway.member.ParticipantGateway
 import com.dobby.backend.domain.gateway.auth.TokenGateway
+import com.dobby.backend.domain.gateway.member.MemberConsentGateway
 import com.dobby.backend.domain.model.member.Member
+import com.dobby.backend.domain.model.member.MemberConsent
 import com.dobby.backend.domain.model.member.Participant
 import com.dobby.backend.infrastructure.database.entity.enums.*
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
@@ -12,10 +14,12 @@ import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
 import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
 class CreateParticipantUseCase (
     private val participantGateway: ParticipantGateway,
+    private val memberConsentGateway: MemberConsentGateway,
     private val tokenGateway: TokenGateway,
     private val idGenerator: IdGenerator
 ): UseCase<CreateParticipantUseCase.Input, CreateParticipantUseCase.Output>
@@ -30,6 +34,8 @@ class CreateParticipantUseCase (
         var basicAddressInfo: AddressInfo,
         var additionalAddressInfo: AddressInfo,
         var matchType: MatchType?,
+        var adConsent: Boolean,
+        var matchConsent: Boolean
     )
 
     data class AddressInfo(
@@ -86,7 +92,14 @@ class CreateParticipantUseCase (
             name = input.name,
         )
 
-        return Participant.newParticipant(
+        val memberConsent = MemberConsent.newConsent(
+            memberId = member.id,
+            adConsent = input.adConsent,
+            matchConsent = input.matchConsent,
+        )
+        memberConsentGateway.save(memberConsent)
+
+        val participant= Participant.newParticipant(
             id = idGenerator.generateId(),
             member = member,
             gender = input.gender,
@@ -101,5 +114,7 @@ class CreateParticipantUseCase (
             ),
             matchType = input.matchType
         )
+
+        return participantGateway.save(participant)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateResearcherUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateResearcherUseCase.kt
@@ -5,7 +5,9 @@ import com.dobby.backend.domain.IdGenerator
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.member.ResearcherGateway
 import com.dobby.backend.domain.gateway.auth.TokenGateway
+import com.dobby.backend.domain.gateway.member.MemberConsentGateway
 import com.dobby.backend.domain.model.member.Member
+import com.dobby.backend.domain.model.member.MemberConsent
 import com.dobby.backend.domain.model.member.Researcher
 import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
 import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
@@ -14,6 +16,7 @@ import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 class CreateResearcherUseCase(
     private val memberGateway: MemberGateway,
     private val researcherGateway: ResearcherGateway,
+    private val memberConsentGateway: MemberConsentGateway,
     private val tokenGateway: TokenGateway,
     private val idGenerator: IdGenerator
 ) : UseCase<CreateResearcherUseCase.Input, CreateResearcherUseCase.Output> {
@@ -25,7 +28,8 @@ class CreateResearcherUseCase(
         val univName: String,
         val name : String,
         val major: String,
-        val labInfo : String?
+        val labInfo : String?,
+        var adConsent: Boolean,
     )
 
     data class Output(
@@ -75,6 +79,13 @@ class CreateResearcherUseCase(
             name = input.name,
         )
 
+        val memberConsent = MemberConsent.newConsent(
+            memberId = member.id,
+            adConsent = input.adConsent,
+            matchConsent = false
+        )
+        memberConsentGateway.save(memberConsent)
+
         val researcher = Researcher.newResearcher(
             id = idGenerator.generateId(),
             member = member,
@@ -84,6 +95,7 @@ class CreateResearcherUseCase(
             major = input.major,
             labInfo = input.labInfo
         )
+
         return researcherGateway.save(researcher)
     }
 

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateResearcherUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateResearcherUseCase.kt
@@ -79,13 +79,6 @@ class CreateResearcherUseCase(
             name = input.name,
         )
 
-        val memberConsent = MemberConsent.newConsent(
-            memberId = member.id,
-            adConsent = input.adConsent,
-            matchConsent = false
-        )
-        memberConsentGateway.save(memberConsent)
-
         val researcher = Researcher.newResearcher(
             id = idGenerator.generateId(),
             member = member,
@@ -95,6 +88,13 @@ class CreateResearcherUseCase(
             major = input.major,
             labInfo = input.labInfo
         )
+
+        val memberConsent = MemberConsent.newConsent(
+            memberId = member.id,
+            adConsent = input.adConsent,
+            matchConsent = false
+        )
+        memberConsentGateway.save(memberConsent)
 
         return researcherGateway.save(researcher)
     }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateResearcherUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateResearcherUseCase.kt
@@ -88,6 +88,7 @@ class CreateResearcherUseCase(
             major = input.major,
             labInfo = input.labInfo
         )
+        researcherGateway.save(researcher)
 
         val memberConsent = MemberConsent.newConsent(
             memberId = member.id,
@@ -96,7 +97,7 @@ class CreateResearcherUseCase(
         )
         memberConsentGateway.save(memberConsent)
 
-        return researcherGateway.save(researcher)
+        return researcher
     }
 
 }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/GetParticipantInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/GetParticipantInfoUseCase.kt
@@ -1,7 +1,9 @@
 package com.dobby.backend.application.usecase.member
 
 import com.dobby.backend.application.usecase.UseCase
+import com.dobby.backend.domain.exception.MemberConsentNotFoundException
 import com.dobby.backend.domain.exception.ParticipantNotFoundException
+import com.dobby.backend.domain.gateway.member.MemberConsentGateway
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.member.ParticipantGateway
 import com.dobby.backend.domain.model.member.Member
@@ -12,7 +14,8 @@ import java.time.LocalDate
 
 class GetParticipantInfoUseCase(
     private val memberGateway: MemberGateway,
-    private val participantGateway: ParticipantGateway
+    private val participantGateway: ParticipantGateway,
+    private val memberConsentGateway: MemberConsentGateway
 ) : UseCase<GetParticipantInfoUseCase.Input, GetParticipantInfoUseCase.Output>{
     data class Input(
         val memberId: String,
@@ -24,7 +27,9 @@ class GetParticipantInfoUseCase(
         val birthDate: LocalDate,
         val basicAddressInfo: Participant.AddressInfo,
         val additionalAddressInfo: Participant.AddressInfo?,
-        val matchType: MatchType?
+        val matchType: MatchType?,
+        val adConsent: Boolean,
+        val matchConsent: Boolean
     )
 
     override fun execute(input: Input): Output {
@@ -32,6 +37,8 @@ class GetParticipantInfoUseCase(
         val member = memberGateway.getById(memberId)
         val participant = participantGateway.findByMemberId(memberId)
             ?: throw ParticipantNotFoundException
+        val participantConsent = memberConsentGateway.findByMemberId(memberId)
+            ?: throw MemberConsentNotFoundException
 
         return Output(
             member = member,
@@ -39,7 +46,9 @@ class GetParticipantInfoUseCase(
             birthDate = participant.birthDate,
             basicAddressInfo = participant.basicAddressInfo,
             additionalAddressInfo = participant.additionalAddressInfo,
-            matchType = participant.matchType
+            matchType = participant.matchType,
+            adConsent = participantConsent.adConsent,
+            matchConsent = participantConsent.matchConsent
         )
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/GetResearcherInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/GetResearcherInfoUseCase.kt
@@ -1,14 +1,17 @@
 package com.dobby.backend.application.usecase.member
 
 import com.dobby.backend.application.usecase.UseCase
+import com.dobby.backend.domain.exception.MemberConsentNotFoundException
 import com.dobby.backend.domain.exception.ResearcherNotFoundException
+import com.dobby.backend.domain.gateway.member.MemberConsentGateway
 import com.dobby.backend.domain.gateway.member.ResearcherGateway
 import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.presentation.api.dto.response.member.MemberResponse
 import io.swagger.v3.oas.annotations.media.Schema
 
 class GetResearcherInfoUseCase(
-    private val researcherGateway: ResearcherGateway
+    private val researcherGateway: ResearcherGateway,
+    private val memberConsentGateway: MemberConsentGateway
 ) : UseCase<GetResearcherInfoUseCase.Input, GetResearcherInfoUseCase.Output>{
     data class Input(
         val memberId: String
@@ -20,11 +23,14 @@ class GetResearcherInfoUseCase(
         val univName: String,
         val major: String,
         val labInfo: String?,
+        val adConsent: Boolean
     )
 
     override fun execute(input: Input): Output {
         val researcher = researcherGateway.findByMemberId(input.memberId)
             ?: throw ResearcherNotFoundException
+        val researcherConsent = memberConsentGateway.findByMemberId(input.memberId)
+            ?: throw MemberConsentNotFoundException
 
         return Output(
             member = researcher.member,
@@ -32,6 +38,7 @@ class GetResearcherInfoUseCase(
             univName = researcher.univName,
             major = researcher.major,
             labInfo = researcher.labInfo,
+            adConsent = researcherConsent.adConsent
         )
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCase.kt
@@ -67,7 +67,6 @@ class UpdateParticipantInfoUseCase(
 
         val updatedConsent = memberConsentGateway.save(
             participantConsent.update(
-                memberId = updatedParticipant.member.id,
                 adConsent = input.adConsent,
                 matchConsent = input.matchConsent
             )

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCase.kt
@@ -2,7 +2,9 @@ package com.dobby.backend.application.usecase.member
 
 import com.dobby.backend.application.usecase.UseCase
 import com.dobby.backend.domain.exception.ContactEmailDuplicateException
+import com.dobby.backend.domain.exception.MemberConsentNotFoundException
 import com.dobby.backend.domain.exception.ParticipantNotFoundException
+import com.dobby.backend.domain.gateway.member.MemberConsentGateway
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.member.ParticipantGateway
 import com.dobby.backend.domain.model.member.Member
@@ -13,7 +15,8 @@ import java.time.LocalDate
 
 class UpdateParticipantInfoUseCase(
     private val participantGateway: ParticipantGateway,
-    private val memberGateway: MemberGateway
+    private val memberGateway: MemberGateway,
+    private val memberConsentGateway: MemberConsentGateway
 ) : UseCase<UpdateParticipantInfoUseCase.Input, UpdateParticipantInfoUseCase.Output> {
 
     data class Input(
@@ -22,7 +25,9 @@ class UpdateParticipantInfoUseCase(
         val name: String,
         val basicAddressInfo: Participant.AddressInfo,
         val additionalAddressInfo: Participant.AddressInfo?,
-        val matchType: MatchType?
+        val matchType: MatchType?,
+        var adConsent: Boolean,
+        var matchConsent: Boolean
     )
 
     data class Output(
@@ -31,12 +36,16 @@ class UpdateParticipantInfoUseCase(
         val birthDate: LocalDate,
         val basicAddressInfo: Participant.AddressInfo,
         val additionalAddressInfo: Participant.AddressInfo?,
-        val matchType: MatchType?
+        val matchType: MatchType?,
+        val adConsent: Boolean,
+        val matchConsent: Boolean
     )
 
     override fun execute(input: Input): Output {
         val participant = participantGateway.findByMemberId(input.memberId)
             ?: throw ParticipantNotFoundException
+        val participantConsent = memberConsentGateway.findByMemberId(input.memberId)
+            ?: throw MemberConsentNotFoundException
         if (memberGateway.existsByContactEmail(input.contactEmail) && participant.member.contactEmail != input.contactEmail) {
             throw ContactEmailDuplicateException
         }
@@ -56,13 +65,24 @@ class UpdateParticipantInfoUseCase(
             )
         )
 
+        val updatedConsent = memberConsentGateway.save(
+            participantConsent.update(
+                memberId = updatedParticipant.member.id,
+                adConsent = input.adConsent,
+                matchConsent = input.matchConsent
+            )
+        )
+
+
         return Output(
             member = updatedParticipant.member,
             gender = updatedParticipant.gender,
             birthDate = updatedParticipant.birthDate,
             basicAddressInfo = updatedParticipant.basicAddressInfo,
             additionalAddressInfo = updatedParticipant.additionalAddressInfo,
-            matchType = updatedParticipant.matchType
+            matchType = updatedParticipant.matchType,
+            adConsent = updatedConsent.adConsent,
+            matchConsent = updatedConsent.matchConsent
         )
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCase.kt
@@ -26,8 +26,8 @@ class UpdateParticipantInfoUseCase(
         val basicAddressInfo: Participant.AddressInfo,
         val additionalAddressInfo: Participant.AddressInfo?,
         val matchType: MatchType?,
-        var adConsent: Boolean,
-        var matchConsent: Boolean
+        val adConsent: Boolean,
+        val matchConsent: Boolean
     )
 
     data class Output(

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateResearcherInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateResearcherInfoUseCase.kt
@@ -2,14 +2,18 @@ package com.dobby.backend.application.usecase.member
 
 import com.dobby.backend.application.usecase.UseCase
 import com.dobby.backend.domain.exception.ContactEmailDuplicateException
+import com.dobby.backend.domain.exception.MemberConsentNotFoundException
 import com.dobby.backend.domain.exception.ResearcherNotFoundException
+import com.dobby.backend.domain.gateway.member.MemberConsentGateway
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.member.ResearcherGateway
 import com.dobby.backend.domain.model.member.Member
+import io.swagger.v3.oas.annotations.media.Schema
 
 class UpdateResearcherInfoUseCase(
     private val researcherGateway: ResearcherGateway,
-    private val memberGateway: MemberGateway
+    private val memberGateway: MemberGateway,
+    private val memberConsentGateway: MemberConsentGateway
 ) : UseCase<UpdateResearcherInfoUseCase.Input, UpdateResearcherInfoUseCase.Output> {
     data class Input(
         val memberId: String,
@@ -17,7 +21,8 @@ class UpdateResearcherInfoUseCase(
         val name: String,
         val univName: String,
         val major: String,
-        val labInfo: String?
+        val labInfo: String?,
+        var adConsent: Boolean,
     )
 
     data class Output(
@@ -25,13 +30,16 @@ class UpdateResearcherInfoUseCase(
         val univEmail: String,
         val univName: String,
         val major: String,
-        val labInfo: String?
+        val labInfo: String?,
+        val adConsent: Boolean
     )
 
     override fun execute(input: Input): Output {
         val researcher = researcherGateway.findByMemberId(input.memberId)
             ?: throw ResearcherNotFoundException
-        if (memberGateway.existsByContactEmail(input.contactEmail)&& researcher.member.contactEmail != input.contactEmail) {
+        val researcherConsent = memberConsentGateway.findByMemberId(input.memberId)
+            ?: throw MemberConsentNotFoundException
+        if (memberGateway.existsByContactEmail(input.contactEmail) && researcher.member.contactEmail != input.contactEmail) {
             throw ContactEmailDuplicateException
         }
 
@@ -45,12 +53,21 @@ class UpdateResearcherInfoUseCase(
             )
         )
 
+        val updatedConsent = memberConsentGateway.save(
+            researcherConsent.update(
+                memberId = updatedResearcher.member.id,
+                adConsent = input.adConsent,
+                matchConsent = false
+            )
+        )
+
         return Output(
             member = updatedResearcher.member,
             univEmail = updatedResearcher.univEmail,
             univName = updatedResearcher.univName,
             major = updatedResearcher.major,
-            labInfo = updatedResearcher.labInfo
+            labInfo = updatedResearcher.labInfo,
+            adConsent = updatedConsent.adConsent
         )
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateResearcherInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateResearcherInfoUseCase.kt
@@ -22,7 +22,7 @@ class UpdateResearcherInfoUseCase(
         val univName: String,
         val major: String,
         val labInfo: String?,
-        var adConsent: Boolean,
+        val adConsent: Boolean,
     )
 
     data class Output(

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateResearcherInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateResearcherInfoUseCase.kt
@@ -55,7 +55,6 @@ class UpdateResearcherInfoUseCase(
 
         val updatedConsent = memberConsentGateway.save(
             researcherConsent.update(
-                memberId = updatedResearcher.member.id,
                 adConsent = input.adConsent,
                 matchConsent = false
             )

--- a/src/main/kotlin/com/dobby/backend/domain/exception/DobbyException.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/exception/DobbyException.kt
@@ -52,6 +52,7 @@ data object ParticipantNotFoundException : ClientException("ME0004", "Participan
 data object EmailNotValidateException : ClientException("ME0005", "You should validate your school email first", HttpStatus.BAD_REQUEST)
 data object SignupOauthEmailDuplicateException : ClientException("ME0006", "You've already joined with requested oauth email", HttpStatus.CONFLICT)
 data object ContactEmailDuplicateException: ClientException("ME0007", "This contact email is already in use.", HttpStatus.CONFLICT)
+data object MemberConsentNotFoundException : ClientException("ME0008", "Member Consent Not Found.", HttpStatus.NOT_FOUND)
 
 /**
  * Experiment error codes

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberConsentGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberConsentGateway.kt
@@ -4,4 +4,5 @@ import com.dobby.backend.domain.model.member.MemberConsent
 
 interface MemberConsentGateway {
     fun save(savedConsent: MemberConsent): MemberConsent
+    fun findByMemberId(memberId: String): MemberConsent?
 }

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberConsentGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberConsentGateway.kt
@@ -1,0 +1,7 @@
+package com.dobby.backend.domain.gateway.member
+
+import com.dobby.backend.domain.model.member.MemberConsent
+
+interface MemberConsentGateway {
+    fun save(savedConsent: MemberConsent): MemberConsent
+}

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/MemberConsent.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/MemberConsent.kt
@@ -41,12 +41,16 @@ data class MemberConsent(
         return this.copy(
             adConsent = adConsent,
             matchConsent = matchConsent,
-            adConsentedAt = if (adConsent != this.adConsent) {
-                if(adConsent) nowDate else null
-            } else { this.adConsentedAt },
-            matchConsentedAt = if(matchConsent != this.matchConsent) {
-                if(matchConsent) nowDate else null
-            } else { this.matchConsentedAt },
+            adConsentedAt = when {
+                adConsent == this.adConsent -> this.adConsentedAt
+                adConsent -> nowDate
+                else -> null
+            },
+            matchConsentedAt = when {
+                matchConsent == this.matchConsent -> this.matchConsentedAt
+                matchConsent -> nowDate
+                else -> null
+            },
             updatedAt = updatedAt
         )
     }

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/MemberConsent.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/MemberConsent.kt
@@ -33,18 +33,20 @@ data class MemberConsent(
         }
     }
     fun update(
-        memberId: String,
         adConsent: Boolean,
         matchConsent: Boolean,
         updatedAt: LocalDateTime = LocalDateTime.now()
     ): MemberConsent {
         val nowDate = updatedAt.toLocalDate()
         return this.copy(
-            memberId = memberId,
             adConsent = adConsent,
             matchConsent = matchConsent,
-            adConsentedAt = if(adConsent) nowDate else null,
-            matchConsentedAt = if(matchConsent) nowDate else null,
+            adConsentedAt = if (adConsent != this.adConsent) {
+                if(adConsent) nowDate else null
+            } else { this.adConsentedAt },
+            matchConsentedAt = if(matchConsent != this.matchConsent) {
+                if(matchConsent) nowDate else null
+            } else { this.matchConsentedAt },
             updatedAt = updatedAt
         )
     }

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/MemberConsent.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/MemberConsent.kt
@@ -1,0 +1,35 @@
+package com.dobby.backend.domain.model.member
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class MemberConsent(
+    val memberId: String,
+    val adConsent: Boolean,
+    val matchConsent: Boolean,
+    val adConsentedAt: LocalDate?,
+    val matchConsentedAt: LocalDate?,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+) {
+    companion object {
+        fun newConsent(
+            memberId: String,
+            adConsent: Boolean,
+            matchConsent: Boolean,
+            createdAt: LocalDateTime = LocalDateTime.now()
+        ) : MemberConsent {
+            val nowDate = createdAt.toLocalDate()
+
+            return MemberConsent(
+                memberId = memberId,
+                adConsent = adConsent,
+                matchConsent = matchConsent,
+                adConsentedAt = if (adConsent) nowDate else null,
+                matchConsentedAt = if (matchConsent) nowDate else null,
+                createdAt = createdAt,
+                updatedAt = createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/MemberConsent.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/MemberConsent.kt
@@ -32,4 +32,20 @@ data class MemberConsent(
             )
         }
     }
+    fun update(
+        memberId: String,
+        adConsent: Boolean,
+        matchConsent: Boolean,
+        updatedAt: LocalDateTime = LocalDateTime.now()
+    ): MemberConsent {
+        val nowDate = updatedAt.toLocalDate()
+        return this.copy(
+            memberId = memberId,
+            adConsent = adConsent,
+            matchConsent = matchConsent,
+            adConsentedAt = if(adConsent) nowDate else null,
+            matchConsentedAt = if(matchConsent) nowDate else null,
+            updatedAt = updatedAt
+        )
+    }
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberConsentEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberConsentEntity.kt
@@ -1,0 +1,61 @@
+package com.dobby.backend.infrastructure.database.entity.member
+
+import com.dobby.backend.domain.model.member.MemberConsent
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "member_consent")
+class MemberConsentEntity (
+    @Id
+    @Column(name = "member_id", columnDefinition = "CHAR(13)")
+    val memberId: String,
+
+    @Column(name = "ad_consent", nullable = false)
+    val adConsent: Boolean,
+
+    @Column(name = "match_consent", nullable = false)
+    val matchConsent: Boolean,
+
+    @Column(name = "ad_consented_at")
+    val adConsentedAt: LocalDate?,
+
+    @Column(name = "match_consented_at")
+    val matchConsentedAt: LocalDate?,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime,
+
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime,
+){
+
+    fun toDomain() = MemberConsent(
+        memberId = memberId,
+        adConsent = adConsent,
+        matchConsent = matchConsent,
+        adConsentedAt = adConsentedAt,
+        matchConsentedAt = matchConsentedAt,
+        createdAt = createdAt,
+        updatedAt = updatedAt
+    )
+
+    companion object {
+        fun fromDomain(consent: MemberConsent) = with(consent) {
+            MemberConsentEntity(
+                memberId = memberId,
+                adConsent = adConsent,
+                matchConsent = matchConsent,
+                adConsentedAt = adConsentedAt,
+                matchConsentedAt = matchConsentedAt,
+                createdAt = createdAt,
+                updatedAt = updatedAt
+            )
+        }
+    }
+
+}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import com.dobby.backend.infrastructure.database.entity.enums.experiment.RecruitStatus
 import com.dobby.backend.infrastructure.database.entity.experiment.*
 import com.dobby.backend.infrastructure.database.entity.member.ParticipantEntity
+import com.dobby.backend.infrastructure.database.entity.member.QMemberConsentEntity
 import com.dobby.backend.infrastructure.database.entity.member.QMemberEntity
 import com.dobby.backend.infrastructure.database.entity.member.QParticipantEntity
 import com.querydsl.core.types.OrderSpecifier
@@ -221,6 +222,7 @@ class ExperimentPostCustomRepositoryImpl (
         val targetGroup = QTargetGroupEntity.targetGroupEntity
         val participant = QParticipantEntity.participantEntity
         val member = QMemberEntity.memberEntity
+        val memberConsent = QMemberConsentEntity.memberConsentEntity
 
         val currentTime = LocalDateTime.now()
 
@@ -243,7 +245,11 @@ class ExperimentPostCustomRepositoryImpl (
             .select(participant, member.contactEmail)
             .from(participant)
             .join(participant.member, member)
-            .where(participant.member.deletedAt.isNull)
+            .join(memberConsent).on(member.id.eq(memberConsent.memberId))
+            .where(
+                participant.member.deletedAt.isNull,
+                memberConsent.matchConsent.isTrue
+                )
             .fetch()
 
         logger.info("[쿼리 결과] participants count: {}", participants.size)

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberConsentRepository.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberConsentRepository.kt
@@ -1,0 +1,7 @@
+package com.dobby.backend.infrastructure.database.repository
+
+import com.dobby.backend.infrastructure.database.entity.member.MemberConsentEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberConsentRepository: JpaRepository<MemberConsentEntity, String> {
+}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberConsentRepository.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberConsentRepository.kt
@@ -4,4 +4,5 @@ import com.dobby.backend.infrastructure.database.entity.member.MemberConsentEnti
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberConsentRepository: JpaRepository<MemberConsentEntity, String> {
+    fun findByMemberId(memberId: String): MemberConsentEntity?
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberConsentGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberConsentGatewayImpl.kt
@@ -1,0 +1,18 @@
+package com.dobby.backend.infrastructure.gateway.member
+
+import com.dobby.backend.domain.gateway.member.MemberConsentGateway
+import com.dobby.backend.domain.model.member.MemberConsent
+import com.dobby.backend.infrastructure.database.entity.member.MemberConsentEntity
+import com.dobby.backend.infrastructure.database.repository.MemberConsentRepository
+import org.springframework.stereotype.Component
+
+@Component
+class MemberConsentGatewayImpl(
+    private val memberConsentRepository: MemberConsentRepository
+) : MemberConsentGateway {
+    override fun save(savedConsent: MemberConsent): MemberConsent {
+        val savedEntity = memberConsentRepository
+            .save(MemberConsentEntity.fromDomain(savedConsent))
+        return savedEntity.toDomain()
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberConsentGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberConsentGatewayImpl.kt
@@ -2,7 +2,9 @@ package com.dobby.backend.infrastructure.gateway.member
 
 import com.dobby.backend.domain.gateway.member.MemberConsentGateway
 import com.dobby.backend.domain.model.member.MemberConsent
+import com.dobby.backend.domain.model.member.Researcher
 import com.dobby.backend.infrastructure.database.entity.member.MemberConsentEntity
+import com.dobby.backend.infrastructure.database.entity.member.ResearcherEntity
 import com.dobby.backend.infrastructure.database.repository.MemberConsentRepository
 import org.springframework.stereotype.Component
 
@@ -14,5 +16,10 @@ class MemberConsentGatewayImpl(
         val savedEntity = memberConsentRepository
             .save(MemberConsentEntity.fromDomain(savedConsent))
         return savedEntity.toDomain()
+    }
+
+    override fun findByMemberId(memberId: String): MemberConsent? {
+        return memberConsentRepository
+                .findByMemberId(memberId)?.toDomain()
     }
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ParticipantSignupRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ParticipantSignupRequest.kt
@@ -49,4 +49,10 @@ data class ParticipantSignupRequest(
 
     @Schema(description = "선호 실험 진행 방식")
     var matchType: MatchType?,
+
+    @Schema(description = "광고성 정보 이메일/SMS 수신 동의 여부")
+    var adConsent: Boolean,
+
+    @Schema(description = "개인정보 수정 및 이용 동의/실험 추천 혜택 동의 여부")
+    var matchConsent: Boolean
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ResearcherSignupRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ResearcherSignupRequest.kt
@@ -38,5 +38,8 @@ data class ResearcherSignupRequest(
     val major: String,
 
     @Schema(description = "연구실 정보")
-    val labInfo: String?
+    val labInfo: String?,
+
+    @Schema(description = "광고성 정보 이메일/SMS 수신 동의 여부")
+    var adConsent: Boolean,
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/UpdateParticipantInfoRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/UpdateParticipantInfoRequest.kt
@@ -25,4 +25,10 @@ data class UpdateParticipantInfoRequest(
 
     @Schema(description = "선호 실험 진행 방식")
     val matchType: MatchType?,
+
+    @Schema(description = "광고성 정보 이메일/SMS 수신 동의 여부")
+    var adConsent: Boolean,
+
+    @Schema(description = "개인정보 수정 및 이용 동의/실험 추천 혜택 동의 여부")
+    var matchConsent: Boolean
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/UpdateParticipantInfoRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/UpdateParticipantInfoRequest.kt
@@ -5,6 +5,7 @@ import com.dobby.backend.presentation.api.dto.response.member.AddressInfoRespons
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 
 data class UpdateParticipantInfoRequest(
     @Email(message= "연락 받을 이메일이 유효하지 않습니다.")
@@ -26,9 +27,11 @@ data class UpdateParticipantInfoRequest(
     @Schema(description = "선호 실험 진행 방식")
     val matchType: MatchType?,
 
+    @NotNull(message = "광고성 정보 수신 동의 여부는 필수입니다.")
     @Schema(description = "광고성 정보 이메일/SMS 수신 동의 여부")
     var adConsent: Boolean,
 
+    @NotNull(message = "개인정보 이용 동의는 필수입니다.")
     @Schema(description = "개인정보 수정 및 이용 동의/실험 추천 혜택 동의 여부")
     var matchConsent: Boolean
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/UpdateResearcherInfoRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/UpdateResearcherInfoRequest.kt
@@ -24,5 +24,8 @@ data class UpdateResearcherInfoRequest(
     val major: String,
 
     @Schema(description = "연구실 정보")
-    val labInfo: String?
+    val labInfo: String?,
+
+    @Schema(description = "광고성 정보 이메일/SMS 수신 동의 여부")
+    var adConsent: Boolean,
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/UpdateResearcherInfoRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/UpdateResearcherInfoRequest.kt
@@ -3,6 +3,7 @@ package com.dobby.backend.presentation.api.dto.request.member
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 
 data class UpdateResearcherInfoRequest(
 
@@ -26,6 +27,7 @@ data class UpdateResearcherInfoRequest(
     @Schema(description = "연구실 정보")
     val labInfo: String?,
 
+    @NotNull(message = "광고성 정보 수신 동의 여부는 필수입니다.")
     @Schema(description = "광고성 정보 이메일/SMS 수신 동의 여부")
     var adConsent: Boolean,
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ParticipantInfoResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ParticipantInfoResponse.kt
@@ -26,8 +26,8 @@ data class ParticipantInfoResponse(
     val matchType: MatchType?,
 
     @Schema(description = "광고성 정보 이메일/SMS 수신 동의 여부")
-    var adConsent: Boolean,
+    val adConsent: Boolean,
 
     @Schema(description = "개인정보 수정 및 이용 동의/실험 추천 혜택 동의 여부")
-    var matchConsent: Boolean
+    val matchConsent: Boolean
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ParticipantInfoResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ParticipantInfoResponse.kt
@@ -24,4 +24,10 @@ data class ParticipantInfoResponse(
 
     @Schema(description = "매칭 선호 타입")
     val matchType: MatchType?,
+
+    @Schema(description = "광고성 정보 이메일/SMS 수신 동의 여부")
+    var adConsent: Boolean,
+
+    @Schema(description = "개인정보 수정 및 이용 동의/실험 추천 혜택 동의 여부")
+    var matchConsent: Boolean
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ResearcherInfoResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ResearcherInfoResponse.kt
@@ -20,5 +20,5 @@ data class ResearcherInfoResponse(
     val labInfo: String?,
 
     @Schema(description = "광고성 정보 이메일/SMS 수신 동의 여부")
-    var adConsent: Boolean,
+    val adConsent: Boolean,
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ResearcherInfoResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ResearcherInfoResponse.kt
@@ -18,4 +18,7 @@ data class ResearcherInfoResponse(
 
     @Schema(description = "연구실 정보")
     val labInfo: String?,
+
+    @Schema(description = "광고성 정보 이메일/SMS 수신 동의 여부")
+    var adConsent: Boolean,
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
@@ -8,6 +8,7 @@ import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import com.dobby.backend.presentation.api.dto.request.member.*
 import com.dobby.backend.presentation.api.dto.response.member.*
 import com.dobby.backend.util.getCurrentMemberId
+import io.swagger.v3.oas.annotations.media.Schema
 
 object MemberMapper {
     fun toCreateResearcherInput(req: ResearcherSignupRequest) : CreateResearcherUseCase.Input{
@@ -113,6 +114,7 @@ object MemberMapper {
             univName = response.univName,
             major = response.major,
             labInfo = response.labInfo,
+            adConsent = response.adConsent
         )
     }
 
@@ -129,7 +131,9 @@ object MemberMapper {
             birthDate = output.birthDate,
             basicAddressInfo = AddressInfoResponse.fromDomain(output.basicAddressInfo),
             additionalAddressInfo = output.additionalAddressInfo?.let { AddressInfoResponse.fromDomain(it) },
-            matchType = output.matchType
+            matchType = output.matchType,
+            adConsent = output.adConsent,
+            matchConsent = output.matchConsent
         )
     }
 
@@ -140,7 +144,8 @@ object MemberMapper {
             name = request.name,
             univName = request.univName,
             major = request.major,
-            labInfo = request.labInfo
+            labInfo = request.labInfo,
+            adConsent = request.adConsent
         )
     }
 
@@ -151,6 +156,7 @@ object MemberMapper {
             univName = response.univName,
             major = response.major,
             labInfo = response.labInfo,
+            adConsent = response.adConsent
         )
     }
 
@@ -167,7 +173,9 @@ object MemberMapper {
                 region = request.additionalAddressInfo?.region ?: Region.NONE,
                 area = request.additionalAddressInfo?.area ?: Area.NONE
             ),
-            matchType = request.matchType
+            matchType = request.matchType,
+            adConsent = request.adConsent,
+            matchConsent = request.matchConsent
         )
     }
 
@@ -178,7 +186,9 @@ object MemberMapper {
             birthDate = output.birthDate,
             basicAddressInfo = AddressInfoResponse.fromDomain(output.basicAddressInfo),
             additionalAddressInfo = output.additionalAddressInfo?.let { AddressInfoResponse.fromDomain(it) },
-            matchType = output.matchType
+            matchType = output.matchType,
+            adConsent = output.adConsent,
+            matchConsent = output.matchConsent
         )
     }
 

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
@@ -8,7 +8,6 @@ import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import com.dobby.backend.presentation.api.dto.request.member.*
 import com.dobby.backend.presentation.api.dto.response.member.*
 import com.dobby.backend.util.getCurrentMemberId
-import io.swagger.v3.oas.annotations.media.Schema
 
 object MemberMapper {
     fun toCreateResearcherInput(req: ResearcherSignupRequest) : CreateResearcherUseCase.Input{

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
@@ -19,7 +19,8 @@ object MemberMapper {
             univName = req.univName,
             name = req.name,
             major = req.major,
-            labInfo = req.labInfo
+            labInfo = req.labInfo,
+            adConsent = req.adConsent,
         )
     }
 
@@ -47,7 +48,9 @@ object MemberMapper {
                 region = req.additionalAddressInfo?.region ?: Region.NONE,
                 area = req.additionalAddressInfo?.area ?: Area.NONE
             ),
-            matchType = req.matchType
+            matchType = req.matchType,
+            adConsent = req.adConsent,
+            matchConsent = req.matchConsent
         )
     }
 

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCaseTest.kt
@@ -2,8 +2,10 @@ package com.dobby.backend.application.usecase.member
 
 import com.dobby.backend.domain.IdGenerator
 import com.dobby.backend.domain.gateway.auth.TokenGateway
+import com.dobby.backend.domain.gateway.member.MemberConsentGateway
 import com.dobby.backend.domain.gateway.member.ParticipantGateway
 import com.dobby.backend.domain.model.member.Member
+import com.dobby.backend.domain.model.member.MemberConsent
 import com.dobby.backend.domain.model.member.Participant
 import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
@@ -14,15 +16,17 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import java.time.LocalDate
 
 class CreateParticipantUseCaseTest: BehaviorSpec ({
 
     val participantGateway: ParticipantGateway = mockk()
+    val memberConsentGateway: MemberConsentGateway = mockk()
     val tokenGateway: TokenGateway = mockk()
     val idGenerator: IdGenerator = mockk()
 
-    val createParticipantUseCase = CreateParticipantUseCase(participantGateway, tokenGateway, idGenerator)
+    val createParticipantUseCase = CreateParticipantUseCase(participantGateway, memberConsentGateway, tokenGateway, idGenerator)
 
     given("유효한 입력을 받았을 때") {
         val input = CreateParticipantUseCase.Input(
@@ -40,7 +44,9 @@ class CreateParticipantUseCaseTest: BehaviorSpec ({
                 region = Region.SEOUL,
                 area = Area.SEODAEMUNGU
             ),
-            matchType = null
+            matchType = null,
+            adConsent = true,
+            matchConsent = true
         )
 
         val member = Member.newMember(
@@ -50,6 +56,12 @@ class CreateParticipantUseCaseTest: BehaviorSpec ({
             provider = input.provider,
             role = RoleType.PARTICIPANT,
             name = input.name
+        )
+
+        val memberConsent = MemberConsent.newConsent(
+            memberId = member.id,
+            adConsent = input.adConsent,
+            matchConsent = input.matchConsent,
         )
 
         val participant = Participant.newParticipant(
@@ -74,6 +86,7 @@ class CreateParticipantUseCaseTest: BehaviorSpec ({
 
         every { idGenerator.generateId() } returns "1"
         every { participantGateway.save(any()) } returns savedParticipant
+        every { memberConsentGateway.save(match { it.memberId == member.id }) } returns memberConsent
         every { tokenGateway.generateAccessToken(any()) } returns accessToken
         every { tokenGateway.generateRefreshToken(any()) } returns refreshToken
 
@@ -90,6 +103,9 @@ class CreateParticipantUseCaseTest: BehaviorSpec ({
                 output.memberInfo.oauthEmail shouldBe savedParticipant.member.oauthEmail
                 output.memberInfo.provider shouldBe savedParticipant.member.provider
                 output.memberInfo.role shouldBe savedParticipant.member.role
+            }
+            Then("MemberConsent가 저장되어야 한다") {
+                verify { memberConsentGateway.save(match { it.memberId == member.id }) }
             }
         }
     }

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCaseTest.kt
@@ -57,13 +57,6 @@ class CreateParticipantUseCaseTest: BehaviorSpec ({
             role = RoleType.PARTICIPANT,
             name = input.name
         )
-
-        val memberConsent = MemberConsent.newConsent(
-            memberId = member.id,
-            adConsent = input.adConsent,
-            matchConsent = input.matchConsent,
-        )
-
         val participant = Participant.newParticipant(
             id = "1",
             member = member,
@@ -79,6 +72,13 @@ class CreateParticipantUseCaseTest: BehaviorSpec ({
             ),
             matchType = input.matchType
         )
+
+        val memberConsent = MemberConsent.newConsent(
+            memberId = member.id,
+            adConsent = input.adConsent,
+            matchConsent = input.matchConsent,
+        )
+
 
         val savedParticipant = participant.copy(member = member.copy(id = "1"))
         val accessToken = "mock-access-token"

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/CreateResearcherUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/CreateResearcherUseCaseTest.kt
@@ -49,12 +49,6 @@ class CreateResearcherUseCaseTest : BehaviorSpec({
             name = input.name
         )
 
-        val memberConsent = MemberConsent.newConsent(
-            memberId = member.id,
-            adConsent = input.adConsent,
-            matchConsent = false,
-        )
-
         val researcher = Researcher.newResearcher(
             id = "1",
             member = member,
@@ -63,6 +57,12 @@ class CreateResearcherUseCaseTest : BehaviorSpec({
             emailVerified = true,
             major = input.major,
             labInfo = input.labInfo
+        )
+
+        val memberConsent = MemberConsent.newConsent(
+            memberId = member.id,
+            adConsent = input.adConsent,
+            matchConsent = false,
         )
 
         val savedMember = member.copy(id = "1", status = MemberStatus.ACTIVE)

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/GetParticipantInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/GetParticipantInfoUseCaseTest.kt
@@ -1,9 +1,11 @@
 package com.dobby.backend.application.usecase.member
 
 import com.dobby.backend.domain.exception.ParticipantNotFoundException
+import com.dobby.backend.domain.gateway.member.MemberConsentGateway
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.member.ParticipantGateway
 import com.dobby.backend.domain.model.member.Member
+import com.dobby.backend.domain.model.member.MemberConsent
 import com.dobby.backend.domain.model.member.Participant
 import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
@@ -19,18 +21,21 @@ import java.time.LocalDate
 class GetParticipantInfoUseCaseTest : BehaviorSpec({
     val memberGateway = mockk<MemberGateway>()
     val participantGateway = mockk<ParticipantGateway>()
-    val useCase = GetParticipantInfoUseCase(memberGateway, participantGateway)
+    val memberConsentGateway = mockk<MemberConsentGateway>()
+    val useCase = GetParticipantInfoUseCase(memberGateway, participantGateway, memberConsentGateway)
 
     given("유효한 memberId가 주어졌을 때") {
         val memberId = "1"
 
-        val member = mockk<Member>()
-        val participant = mockk<Participant>()
+        val member = mockk<Member>(relaxed = true)
+        val participant = mockk<Participant>(relaxed = true)
+        val memberConsent = mockk<MemberConsent>(relaxed = true)
         val basicAddressInfo = Participant.AddressInfo(region = Region.SEOUL, area = Area.GWANGJINGU)
         val additionalAddressInfo = Participant.AddressInfo(region = Region.INCHEON, area = Area.SEOGU)
 
         every { memberGateway.getById(memberId) } returns member
         every { participantGateway.findByMemberId(memberId) } returns participant
+        every { memberConsentGateway.findByMemberId(memberId) } returns memberConsent
         every { participant.gender } returns GenderType.FEMALE
         every { participant.birthDate } returns LocalDate.of(2000, 7, 8)
         every { participant.basicAddressInfo } returns basicAddressInfo

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/GetResearcherInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/GetResearcherInfoUseCaseTest.kt
@@ -1,8 +1,10 @@
 package com.dobby.backend.application.usecase.member
 
 import com.dobby.backend.domain.exception.ResearcherNotFoundException
+import com.dobby.backend.domain.gateway.member.MemberConsentGateway
 import com.dobby.backend.domain.gateway.member.ResearcherGateway
 import com.dobby.backend.domain.model.member.Member
+import com.dobby.backend.domain.model.member.MemberConsent
 import com.dobby.backend.domain.model.member.Researcher
 import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
 import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
@@ -17,7 +19,8 @@ import kotlin.test.assertFailsWith
 class GetResearcherInfoUseCaseTest : BehaviorSpec({
     Given("Gateway에 유효한 memberId와 researcherId가 있다면") {
         val researcherGateway = mockk<ResearcherGateway>()
-        val useCase = GetResearcherInfoUseCase(researcherGateway)
+        val memberConsentGateway = mockk<MemberConsentGateway>()
+        val useCase = GetResearcherInfoUseCase(researcherGateway, memberConsentGateway)
 
         val input = GetResearcherInfoUseCase.Input(memberId = "1")
         val mockMember = Member(
@@ -42,7 +45,9 @@ class GetResearcherInfoUseCaseTest : BehaviorSpec({
             emailVerified = true,
         )
 
+        val mockMemberConsent = mockk<MemberConsent>(relaxed = true)
         every { researcherGateway.findByMemberId(input.memberId) } returns mockResearcher
+        every { memberConsentGateway.findByMemberId(input.memberId) } returns mockMemberConsent
 
         `when`("GetResearcherInfoUseCase가 실행되면") {
             val result = useCase.execute(input)
@@ -59,11 +64,13 @@ class GetResearcherInfoUseCaseTest : BehaviorSpec({
 
     given("gateway에 해당 member 정보가 없으면") {
         val researcherGateway = mockk<ResearcherGateway>()
-        val useCase = GetResearcherInfoUseCase(researcherGateway)
+        val memberConsentGateway = mockk<MemberConsentGateway>()
+        val useCase = GetResearcherInfoUseCase(researcherGateway, memberConsentGateway)
 
         val input = GetResearcherInfoUseCase.Input(memberId = "2")
 
         every { researcherGateway.findByMemberId(input.memberId) } returns null
+        every { memberConsentGateway.findByMemberId(input.memberId) } returns null
 
         `when`("GetResearcherInfoUseCase가 실행됐을때") {
             then("ResearcherNotFoundException 예외가 반환된다.") {


### PR DESCRIPTION
## 💡 작업 내용  
회원가입 및 회원 정보 수정 시 이용약관 동의 여부(`MemberConsent`)를 관리할 수 있도록 기능을 추가했습니다.  
아래 주요 변경사항을 포함합니다.

---

### 🔹 **1. `MemberConsent` 엔티티 추가**  
- 회원(`Member`)의 광고 수신 및 매칭 동의 여부를 저장하는 `MemberConsent` 엔티티를 추가했습니다.  
- `member_id`를 PK로 설정하여 회원과 1:1 관계를 유지합니다.
- 주요 필드:  
  - `adConsent`: 광고 이메일/SMS 수신 동의 여부 (`Boolean`)  
  - `matchConsent`: 개인정보 수정 및 매칭 추천 동의 여부 (`Boolean`)  
  - `adConsentedAt`: 광고 동의 일자 (`LocalDate`)  
  - `matchConsentedAt`: 매칭 동의 일자 (`LocalDate`)  

---

### 🔹 **2. 참여자/연구자 회원가입 시 `MemberConsent` 저장 로직 추가**  
- 회원가입 시 동의 여부를 함께 입력받아 `MemberConsent`에 저장하도록 수정했습니다.  
- `ResearcherSignupRequest`, `ParticipantSignupRequest` DTO에 `adConsent`, `matchConsent` 필드 추가.  
- `CreateResearcherUseCase`, `CreateParticipantUseCase`에서 `MemberConsent`를 생성하고 저장하는 로직 추가.  

📌 **회원가입 후 기본 매칭 동의값 (`matchConsent`)**  
![연구자(매칭 기본값false)](https://github.com/user-attachments/assets/2b9f2257-8cf4-4c13-8980-78b8a0f68ffa)  

---

### 🔹 **3. 회원 정보 수정 시 `MemberConsent` 업데이트 기능 추가**  
- 회원이 동의 여부를 변경할 수 있도록, 회원 정보 수정 API에서 `MemberConsent`도 함께 업데이트하도록 수정했습니다.  
- `adConsent` 또는 `matchConsent`가 변경되었을 경우, 해당 `consentedAt` 필드도 업데이트되도록 처리했습니다.  

📌 **연구자 회원 정보 수정 (BEFORE → AFTER)**  
- **수정 전 (`matchConsent = true`)**  
  ![연구자 내정보 수정 BEFORE(TRUE)](https://github.com/user-attachments/assets/418fb686-a53f-4675-ae58-07c6b6a18eb9)  

- **수정 후 (`matchConsent = false`)**  
  ![연구자 내정보 수정 AFTER(FALSE)](https://github.com/user-attachments/assets/58821df7-97d6-438d-b922-daea251b200d)  

📌 **참여자 회원 정보 수정 (BEFORE → AFTER)**  
- **수정 전**  
  ![참여자 내정보 수정](https://github.com/user-attachments/assets/fb6bfd51-1244-4b0e-893b-402422425408)  
- **수정 후**  
  ![참여자 내정보 수정 (after)](https://github.com/user-attachments/assets/243fb5d1-dc82-4112-953d-be2b8309fd67)  

---

### 🔹 **4. 회원 정보 조회 시 `MemberConsent` 포함**  
- 회원 상세 조회 시 `MemberConsent` 정보를 함께 반환하도록 수정했습니다.  
- API 응답에 `adConsent`, `matchConsent`, `adConsentedAt`, `matchConsentedAt` 필드 추가.  

📌 **참여자 내 정보 조회 API 응답 (동의 정보 포함)**  
![연구자 내정보 조회](https://github.com/user-attachments/assets/580abb9b-bf61-4135-af55-897f1fbb897e)  

---

### 🔹 **5. 추천 공고 이메일 전송 로직 수정**  
- 광고 수신에 동의한(`adConsent = true`) 회원에게만 이메일을 발송하도록 쿼리 조건 추가.  
- 기존 `member` 테이블에서 바로 조회하던 방식을, `member_consent` 테이블을 JOIN하여 필터링하도록 변경.  

📌 **매칭 결과 (`matchConsent = true` 일 때는 매칭 대상)**  
![매칭 결과(consent동의시)](https://github.com/user-attachments/assets/bdebb26d-a53e-4378-b3d5-d6f1b2bf3f92)

📌 **매칭 결과 (`matchConsent = false` 로 변경 후에는 매칭 대상이 아님)**  
![매칭결과(consent false로 수정후)](https://github.com/user-attachments/assets/74e716af-17ee-45a0-8962-8dd71705cf2a)  

---

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요

## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
  - 사용자 등록 및 정보 업데이트 시, 광고 수신과 매칭 기능 사용 여부에 대한 동의를 선택할 수 있는 옵션이 추가되었습니다.
  - 사용자 정보 조회 응답에 동의 상태가 포함되어, 개인 설정을 쉽게 확인할 수 있습니다.
- **버그 수정**
  - 중복 이메일에 의한 가입 오류 처리가 강화되어 보다 명확한 안내가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-328