### PR TITLE
[YS-333] fix: AuthorizationDeniedException을 403 Forbidden으로 정상 처리하도록 수정

### DIFF
--- a/src/main/kotlin/com/dobby/backend/presentation/api/config/exception/WebExceptionHandler.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/config/exception/WebExceptionHandler.kt
@@ -56,13 +56,13 @@ class WebExceptionHandler(
 
     @ExceptionHandler(AuthorizationDeniedException::class)
     protected fun handleAuthorizationDeniedException(exception: AuthorizationDeniedException): ExceptionResponseEntity {
-        log.warn("Handling AuthorizationDeniedException: ${exception.message}")
+        log.warn("Handling ${exception::class.simpleName}: ${exception.message}")
         return responseFactory.create(HttpStatus.FORBIDDEN, PermissionDeniedException)
     }
 
     @ExceptionHandler(AccessDeniedException::class)
     protected fun handleAccessDeniedException(exception: AccessDeniedException): ExceptionResponseEntity {
-        log.warn("Handling AccessDeniedException: ${exception.message}")
+        log.warn("Handling ${exception::class.simpleName}: ${exception.message}")
         return responseFactory.create(HttpStatus.FORBIDDEN, PermissionDeniedException)
     }
 

--- a/src/main/kotlin/com/dobby/backend/presentation/api/config/exception/WebExceptionHandler.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/config/exception/WebExceptionHandler.kt
@@ -54,14 +54,13 @@ class WebExceptionHandler(
         return responseFactory.create(HttpStatus.NOT_FOUND, InvalidRequestValueException)
     }
 
-    @ExceptionHandler(AuthorizationDeniedException::class)
-    protected fun handleAuthorizationDeniedException(exception: AuthorizationDeniedException): ExceptionResponseEntity {
-        log.warn("Handling ${exception::class.simpleName}: ${exception.message}")
-        return responseFactory.create(HttpStatus.FORBIDDEN, PermissionDeniedException)
-    }
-
-    @ExceptionHandler(AccessDeniedException::class)
-    protected fun handleAccessDeniedException(exception: AccessDeniedException): ExceptionResponseEntity {
+    @ExceptionHandler(
+        value = [
+            AuthorizationDeniedException::class,
+            AccessDeniedException::class
+        ]
+    )
+    protected fun handlePermissionDeniedException(exception: Exception): ExceptionResponseEntity {
         log.warn("Handling ${exception::class.simpleName}: ${exception.message}")
         return responseFactory.create(HttpStatus.FORBIDDEN, PermissionDeniedException)
     }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/config/exception/WebExceptionHandler.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/config/exception/WebExceptionHandler.kt
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.core.env.Environment
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.authorization.AuthorizationDeniedException
 import org.springframework.validation.BindException
 import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
@@ -51,6 +52,18 @@ class WebExceptionHandler(
     protected fun handleNotFoundException(exception: NoResourceFoundException): ExceptionResponseEntity {
         log.warn("Handling ${exception::class.simpleName}: ${exception.message}")
         return responseFactory.create(HttpStatus.NOT_FOUND, InvalidRequestValueException)
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException::class)
+    protected fun handleAuthorizationDeniedException(exception: AuthorizationDeniedException): ExceptionResponseEntity {
+        log.warn("Handling AuthorizationDeniedException: ${exception.message}")
+        return responseFactory.create(HttpStatus.FORBIDDEN, PermissionDeniedException)
+    }
+
+    @ExceptionHandler(AccessDeniedException::class)
+    protected fun handleAccessDeniedException(exception: AccessDeniedException): ExceptionResponseEntity {
+        log.warn("Handling AccessDeniedException: ${exception.message}")
+        return responseFactory.create(HttpStatus.FORBIDDEN, PermissionDeniedException)
     }
 
     @ExceptionHandler(DobbyException::class)


### PR DESCRIPTION
## 💡 작업 내용
- 역할에 맞지 않는 API를 호출할 때 발생하는 `500 Internal Server Error` 문제를 해결하기 위해, `WebExceptionHandler`에서 `AccessDeniedException`을 처리하여 `403 Forbidden`을 반환하도록 수정
<img width="440" alt="스크린샷 2025-02-16 오후 5 29 28" src="https://github.com/user-attachments/assets/1cc03500-c87e-47c4-a266-8d1259e65562" />

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 권한이나 접근이 거부된 상황에서, 사용자에게 403 오류를 명확히 안내하는 개선된 오류 처리 기능이 추가되었습니다.
	- 이번 업데이트로 인해, 제한된 접근 시 일관된 응답 메시지가 제공되어 보안성과 사용자 경험이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
