### PR TITLE
[YS-340] fix: 매칭 공고 이메일 전송 시 대상이 올바르게 필터링되지 않는 현상 해결

### DIFF
--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepositoryImpl.kt
@@ -24,6 +24,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.time.Period
 
 @Repository
 class ExperimentPostCustomRepositoryImpl (
@@ -222,7 +223,7 @@ class ExperimentPostCustomRepositoryImpl (
         val targetGroup = QTargetGroupEntity.targetGroupEntity
         val participant = QParticipantEntity.participantEntity
         val member = QMemberEntity.memberEntity
-        val memberConsent = QMemberConsentEntity.memberConsentEntity
+       val memberConsent = QMemberConsentEntity.memberConsentEntity
 
         val currentTime = LocalDateTime.now()
 
@@ -266,8 +267,8 @@ class ExperimentPostCustomRepositoryImpl (
             val birthDate = participantEntity.birthDate
 
             contactEmail?.let {
-                val currentYear = LocalDate.now().year
-                val participantAge = currentYear - birthDate.year + 1
+                val today = LocalDate.now()
+                val participantAge = Period.between(birthDate, today).years
 
                 val matchedPosts = todayPosts.filter { post ->
                     val matchResults = listOf(
@@ -333,7 +334,7 @@ class ExperimentPostCustomRepositoryImpl (
     ): Boolean {
         if (participantMatchType == ALL || participantMatchType == null)
             return true
-        if (postMatchType == null)
+        if (postMatchType == OFFLINE || postMatchType == ALL || postMatchType == null)
             return true
         return postMatchType == participantMatchType
     }


### PR DESCRIPTION
## 💡 작업 내용
QA 중 매칭 공고 수동 트리거 API 테스트에서 발견한 버그 현상을 해결했습니다.
1. **나이 매칭 관련: ’만 XX세 - XX세‘**
    - 만 나이가 아닌 기존 서버에서는 한국 나이 기준으로 계산하고 있었음. → 나이 계산 '만' 기준으로 로직 개선
2. **대면, 비대면 로직 관련**
    - 기존 서버에서는 공고의 실험이 ’비대면‘ 일 경우 장소가 매칭된 것으로 판단하는 비즈니스 규칙을 반영하지 못함→ 매칭 로직 개선
## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 리뷰 받기 애매할(?) 정도로 간단한 매칭 로직 개선이라, **바로 HOTFIX 하기 위해 머지**하겠습니다.


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- 참가자 연령 산출 방식을 개선하여 보다 정밀한 결과 필터링이 이루어지도록 했습니다.
	- 실험 포스트 매칭 기준에 오프라인 및 전체 옵션을 추가, 더욱 정교한 매칭 결과를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->