### PR TITLE
[YS-342] hotfix: 회원 정보 수정 시 기존 실험 게시글이 삭제되지 않도록 cascade 설정 변경

### DIFF
--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberEntity.kt
@@ -36,7 +36,7 @@ class MemberEntity(
     @Column(name = "name", length = 10, nullable = true)
     val name: String,
 
-    @OneToMany(mappedBy = "member", cascade = [CascadeType.ALL], orphanRemoval = true)
+    @OneToMany(mappedBy = "member", cascade = [CascadeType.PERSIST, CascadeType.MERGE])
     val experimentPosts: List<ExperimentPostEntity> = mutableListOf(),
 
     @Column(name = "created_at", nullable = false)


### PR DESCRIPTION
## 💡 작업 내용
- 기존 설정(`CascadeType.ALL, orphanRemoval = true`)에서는 `MemberEntity`가 변경될 때, 연관된 `ExperimentPostEntity`가 삭제되는 문제 발생
  - `REMOVE`와 `orphanRemoval = true`가 활성화된 상태에서는 새로운 `MemberEntity`가 저장될 때 기존 `ExperimentPostEntity`가 `orphan(고아 객체)`로 인식되어 삭제됨
- `cascade = [CascadeType.PERSIST, CascadeType.MERGE]`로 변경하여, 연관된 게시글이 유지되도록 수정

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- hotfix라 바로 머지하겠습니다


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터**
	- 회원 관련 게시물의 저장 및 업데이트 처리 방식을 개선하여 데이터 관리 효율성과 무결성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->