### PR TITLE
[YS-66] feat: CloudWatch 로그 전송 및 환경별 로그 그룹 분리 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,8 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.3")
 	implementation("org.springframework.boot:spring-boot-starter-aop")
+	implementation("ca.pjer:logback-awslogs-appender:1.6.0")
+
 	compileOnly("org.projectlombok:lombok")
 	runtimeOnly("com.mysql:mysql-connector-j")
 	runtimeOnly("com.h2database:h2")

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,21 +2,7 @@
 <configuration packagingData="true">
     <timestamp key="timestamp" datePattern="yyyy-MM-dd-HH-mm-ssSSS"/>
 
-    <!-- AWS CloudWatch에 로그를 전송하는 Appender 설정 -->
-    <appender name="aws_cloud_watch_log" class="ca.pjer.logback.AwsLogsAppender">
-        <layout>
-            <pattern>[%thread] [%date] [%level] [%file:%line] - %msg%n</pattern>
-        </layout>
-        <logGroupName>gradmeet</logGroupName>
-        <logStreamUuidPrefix>gradmeet-log</logStreamUuidPrefix>
-        <logRegion>ap-northeast-2</logRegion>
-        <maxBatchLogEvents>50</maxBatchLogEvents>
-        <maxFlushTimeMillis>30000</maxFlushTimeMillis>
-        <maxBlockTimeMillis>5000</maxBlockTimeMillis>
-        <retentionTimeDays>0</retentionTimeDays>
-    </appender>
-
-    <!-- 콘솔 로그 Appender 설정 -->
+    <!-- 콘솔 로그 Appender (모든 환경에서 공통 사용) -->
     <property name="CONSOLE_LOG_PATTERN" value="%highlight(%-5level) %date [%thread] %cyan([%C{0} :: %M :: %L]) - %msg%n"/>
     <appender name="console_log" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
@@ -24,22 +10,48 @@
         </encoder>
     </appender>
 
-    <!-- local 환경에서는 콘솔 로그만 사용 -->
+    <!-- local 환경: 콘솔 로그만 사용 -->
     <springProfile name="local">
         <root level="INFO">
             <appender-ref ref="console_log"/>
         </root>
     </springProfile>
 
-    <!-- dev 환경에서는 AWS CloudWatch로 DEBUG 레벨 로그 전송 -->
+    <!-- dev 환경: AWS CloudWatch에 dev 전용 로그 그룹 사용 -->
     <springProfile name="dev">
+        <appender name="aws_cloud_watch_log" class="ca.pjer.logback.AwsLogsAppender">
+            <layout>
+                <pattern>[%thread] [%date] [%level] [%file:%line] - %msg%n</pattern>
+            </layout>
+            <!-- dev 전용 로그 그룹 -->
+            <logGroupName>gradmeet-dev</logGroupName>
+            <logStreamUuidPrefix>gradmeet-log-dev</logStreamUuidPrefix>
+            <logRegion>ap-northeast-2</logRegion>
+            <maxBatchLogEvents>50</maxBatchLogEvents>
+            <maxFlushTimeMillis>30000</maxFlushTimeMillis>
+            <maxBlockTimeMillis>5000</maxBlockTimeMillis>
+            <retentionTimeDays>0</retentionTimeDays>
+        </appender>
         <root level="DEBUG">
             <appender-ref ref="aws_cloud_watch_log"/>
         </root>
     </springProfile>
 
-    <!-- prod 환경에서는 AWS CloudWatch로 INFO 레벨 로그 전송 -->
+    <!-- prod 환경: AWS CloudWatch에 prod 전용 로그 그룹 사용 -->
     <springProfile name="prod">
+        <appender name="aws_cloud_watch_log" class="ca.pjer.logback.AwsLogsAppender">
+            <layout>
+                <pattern>[%thread] [%date] [%level] [%file:%line] - %msg%n</pattern>
+            </layout>
+            <!-- prod 전용 로그 그룹 -->
+            <logGroupName>gradmeet-prod</logGroupName>
+            <logStreamUuidPrefix>gradmeet-log-prod</logStreamUuidPrefix>
+            <logRegion>ap-northeast-2</logRegion>
+            <maxBatchLogEvents>50</maxBatchLogEvents>
+            <maxFlushTimeMillis>30000</maxFlushTimeMillis>
+            <maxBlockTimeMillis>5000</maxBlockTimeMillis>
+            <retentionTimeDays>0</retentionTimeDays>
+        </appender>
         <root level="INFO">
             <appender-ref ref="aws_cloud_watch_log"/>
         </root>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration packagingData="true">
+    <timestamp key="timestamp" datePattern="yyyy-MM-dd-HH-mm-ssSSS"/>
+
+    <!-- AWS CloudWatch에 로그를 전송하는 Appender 설정 -->
+    <appender name="aws_cloud_watch_log" class="ca.pjer.logback.AwsLogsAppender">
+        <layout>
+            <pattern>[%thread] [%date] [%level] [%file:%line] - %msg%n</pattern>
+        </layout>
+        <logGroupName>gradmeet</logGroupName>
+        <logStreamUuidPrefix>gradmeet-log</logStreamUuidPrefix>
+        <logRegion>ap-northeast-2</logRegion>
+        <maxBatchLogEvents>50</maxBatchLogEvents>
+        <maxFlushTimeMillis>30000</maxFlushTimeMillis>
+        <maxBlockTimeMillis>5000</maxBlockTimeMillis>
+        <retentionTimeDays>0</retentionTimeDays>
+    </appender>
+
+    <!-- 콘솔 로그 Appender 설정 -->
+    <property name="CONSOLE_LOG_PATTERN" value="%highlight(%-5level) %date [%thread] %cyan([%C{0} :: %M :: %L]) - %msg%n"/>
+    <appender name="console_log" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- local 환경에서는 콘솔 로그만 사용 -->
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="console_log"/>
+        </root>
+    </springProfile>
+
+    <!-- dev 환경에서는 AWS CloudWatch로 DEBUG 레벨 로그 전송 -->
+    <springProfile name="dev">
+        <root level="DEBUG">
+            <appender-ref ref="aws_cloud_watch_log"/>
+        </root>
+    </springProfile>
+
+    <!-- prod 환경에서는 AWS CloudWatch로 INFO 레벨 로그 전송 -->
+    <springProfile name="prod">
+        <root level="INFO">
+            <appender-ref ref="aws_cloud_watch_log"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## 💡 작업 내용
- AWS CloudWatch 로그 전송을 위한 Logback Appender 설정 추가
  - dev 환경은 gradmeet-dev 로그 그룹 사용
  - prod 환경은 gradmeet-prod 로그 그룹 사용
  - local 환경은 콘솔 로그만 사용하도록 프로파일 구성

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 테스트를 위하여 일단 리뷰 생략하고 머지하겠습니다


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- AWS CloudWatch를 통한 로그 관리 기능이 추가되어, 시스템 로그 집계 및 모니터링이 강화되었습니다.
	- 로컬, 개발, 프로덕션 환경에 따라 최적화된 로그 출력 및 포맷 설정이 제공되어, 운영과 문제해결 시 보다 효율적인 로그 활용이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->