### PR TITLE
[YS-344] hotfix: S3 SDK v1 → v2 버전 업그레이드

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,9 +50,7 @@ dependencies {
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
 	implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
 	implementation("org.springframework.boot:spring-boot-starter-quartz")
-	implementation("io.awspring.cloud:spring-cloud-starter-aws:2.4.4") {
-		exclude(group = "com.amazonaws")
-	}
+	implementation("software.amazon.awssdk:s3:2.20.59")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.3")
 	implementation("org.springframework.boot:spring-boot-starter-aop")

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/experiment/TargetGroupGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/experiment/TargetGroupGateway.kt
@@ -1,7 +1,0 @@
-package com.dobby.backend.domain.gateway.experiment
-
-import com.amazonaws.services.ec2.model.TargetGroup
-
-interface TargetGroupGateway {
-    fun save(targetGroup: TargetGroup): TargetGroup
-}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/config/S3Config.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/config/S3Config.kt
@@ -1,13 +1,12 @@
 package com.dobby.backend.infrastructure.config
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider
-import com.amazonaws.auth.BasicAWSCredentials
-import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.dobby.backend.infrastructure.config.properties.S3Properties
-import lombok.RequiredArgsConstructor
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
 
 @Configuration
 class S3Config(
@@ -15,12 +14,13 @@ class S3Config(
 ) {
 
     @Bean
-    fun amazonS3Client(): AmazonS3 {
-        val awsCredentialsProvider = BasicAWSCredentials(properties.credentials.accessKey, properties.credentials.secretKey)
-
-        return AmazonS3ClientBuilder.standard()
-            .withRegion(properties.region.static)
-            .withCredentials(AWSStaticCredentialsProvider(awsCredentialsProvider))
+    fun s3Presigner(): S3Presigner {
+        val awsCredentialsProvider = StaticCredentialsProvider.create(
+            AwsBasicCredentials.create(properties.credentials.accessKey, properties.credentials.secretKey)
+        )
+        return S3Presigner.builder()
+            .region(Region.AP_NORTHEAST_2)
+            .credentialsProvider(awsCredentialsProvider)
             .build()
     }
 }

--- a/src/test/kotlin/com/dobby/backend/infrastructure/s3/S3PreSignedUrlProviderTest.kt
+++ b/src/test/kotlin/com/dobby/backend/infrastructure/s3/S3PreSignedUrlProviderTest.kt
@@ -1,14 +1,16 @@
 package com.dobby.backend.infrastructure.s3
 
-import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
 import com.dobby.backend.domain.exception.InvalidRequestValueException
 import com.dobby.backend.domain.IdGenerator
 import com.dobby.backend.infrastructure.config.properties.S3Properties
 import io.kotest.core.spec.style.BehaviorSpec
-import io.mockk.*
+import io.mockk.every
+import io.mockk.mockk
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest
 import java.net.URL
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -18,34 +20,36 @@ import kotlin.test.assertNotNull
 @ActiveProfiles("test")
 class S3PreSignedUrlProviderTest : BehaviorSpec({
 
-    val amazonS3Client = mockk<AmazonS3>()
+    val s3Presigner = mockk<S3Presigner>()
     val s3Properties = mockk<S3Properties>()
-    val s3Config = mockk<S3Properties.S3>()
+    val s3ConfigProperties = mockk<S3Properties.S3>()
     val idGenerator = mockk<IdGenerator>()
 
-    every { s3Properties.s3 } returns s3Config
-    every { s3Config.bucket } returns "test-bucket"
+    every { s3Properties.s3 } returns s3ConfigProperties
+    every { s3ConfigProperties.bucket } returns "test-bucket"
 
-    val provider = S3PreSignedUrlProvider(amazonS3Client, idGenerator, s3Properties)
+    val provider = S3PreSignedUrlProvider(s3Presigner, idGenerator, s3Properties)
 
     given("이미지 파일 이름이 주어지고") {
         val imageName = "test_image.jpg"
-        val mockPresignedUrl = mockk<URL>()
+        val mockUrl = URL("http://example.com/presigned")
+        val mockPresignedRequest = mockk<PresignedPutObjectRequest>()
+
+        every { s3Presigner.presignPutObject(any<PutObjectPresignRequest>()) } returns mockPresignedRequest
+        every { mockPresignedRequest.url() } returns mockUrl
+        every { idGenerator.generateId() } returns "test-tsid"
 
         `when`("S3에서 PreSigned URL을 생성하면") {
-            every { amazonS3Client.generatePresignedUrl(any<GeneratePresignedUrlRequest>()) } returns mockPresignedUrl
-            every { idGenerator.generateId() } returns "test-tsid"
-
             then("PreSigned URL이 반환된다") {
                 val preSignedUrl = provider.getExperimentPostPreSignedUrl(imageName)
                 assertNotNull(preSignedUrl)
-                assertEquals(mockPresignedUrl.toString(), preSignedUrl)
+                assertEquals(mockUrl.toString(), preSignedUrl)
             }
         }
     }
 
     given("파일 이름에 확장자가 없는 경우") {
-        val imageName = "test_image" // 확장자가 없는 파일명
+        val imageName = "test_image" // 확장자 없음
 
         then("InvalidRequestValueException이 발생한다") {
             assertFailsWith<InvalidRequestValueException> {


### PR DESCRIPTION
## 💡 작업 내용
- S3 SDK v1 → v2 버전 업그레이드

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- hotfix라 리뷰 생략하겠습니다


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- S3 파일 업로드 URL 생성 방식이 최신 AWS SDK로 전환되어 보다 안정적이고 효율적으로 동작합니다.
	- 기존에 사용되던 저장 관련 기능이 불필요하여 제거되었습니다.

- **Chores**
	- AWS 관련 종속성이 최신 라이브러리로 업데이트되어 유지보수성이 향상되었습니다.
	- AWS 기능 테스트 코드가 새로운 SDK 사용에 맞게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->