### PR TITLE
[YS-345] feat: 데모데이를 위한 회원 매칭 이메일 동의 여부 조작 API 구현

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/service/SchedulerService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/SchedulerService.kt
@@ -1,6 +1,7 @@
 package com.dobby.backend.application.service
 
 import com.dobby.backend.application.usecase.quartz.TriggerSchedulerUseCase
+import com.dobby.backend.domain.exception.MemberNotFoundException
 import com.dobby.backend.domain.gateway.member.MemberConsentGateway
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import jakarta.transaction.Transactional
@@ -9,14 +10,18 @@ import org.springframework.stereotype.Service
 @Service
 class SchedulerService(
     private val schedulerTriggerUseCase: TriggerSchedulerUseCase,
-    private val memberConsentGateway: MemberConsentGateway
+    private val memberConsentGateway: MemberConsentGateway,
+    private val memberGateway: MemberGateway
 ) {
     @Transactional
     fun triggerSendMatchingEmailJob() {
         schedulerTriggerUseCase.execute(TriggerSchedulerUseCase.Input("matching_email_send_job"))
     }
 
-    fun updateMemberConsent(memberId: String) {
+    @Transactional
+    fun updateMemberConsent(name: String) {
+        val memberId = memberGateway.findMemberIdByName(name)
+            ?: throw MemberNotFoundException
         memberConsentGateway.updateMatchConsent(memberId, false)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/service/SchedulerService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/SchedulerService.kt
@@ -1,15 +1,22 @@
 package com.dobby.backend.application.service
 
 import com.dobby.backend.application.usecase.quartz.TriggerSchedulerUseCase
+import com.dobby.backend.domain.gateway.member.MemberConsentGateway
+import com.dobby.backend.domain.gateway.member.MemberGateway
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 
 @Service
 class SchedulerService(
-    private val schedulerTriggerUseCase: TriggerSchedulerUseCase
+    private val schedulerTriggerUseCase: TriggerSchedulerUseCase,
+    private val memberConsentGateway: MemberConsentGateway
 ) {
     @Transactional
     fun triggerSendMatchingEmailJob() {
         schedulerTriggerUseCase.execute(TriggerSchedulerUseCase.Input("matching_email_send_job"))
+    }
+
+    fun updateMemberConsent(memberId: String) {
+        memberConsentGateway.updateMatchConsent(memberId, false)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberConsentGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberConsentGateway.kt
@@ -5,4 +5,5 @@ import com.dobby.backend.domain.model.member.MemberConsent
 interface MemberConsentGateway {
     fun save(savedConsent: MemberConsent): MemberConsent
     fun findByMemberId(memberId: String): MemberConsent?
+    fun updateMatchConsent(memberId: String, matchConsent: Boolean): MemberConsent
 }

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberGateway.kt
@@ -14,4 +14,5 @@ interface MemberGateway {
     fun findContactEmailByMemberId(memberId: String): String
     fun findByContactEmail(contactEmail: String): Member?
     fun findRoleByIdAndDeletedAtIsNull(memberId: String): RoleType?
+    fun findMemberIdByName(name: String): String?
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberConsentEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberConsentEntity.kt
@@ -19,13 +19,13 @@ class MemberConsentEntity (
     val adConsent: Boolean,
 
     @Column(name = "match_consent", nullable = false)
-    val matchConsent: Boolean,
+    var matchConsent: Boolean,
 
     @Column(name = "ad_consented_at")
     val adConsentedAt: LocalDate?,
 
     @Column(name = "match_consented_at")
-    val matchConsentedAt: LocalDate?,
+    var matchConsentedAt: LocalDate?,
 
     @Column(name = "created_at", nullable = false)
     val createdAt: LocalDateTime,

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberConsentEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberConsentEntity.kt
@@ -18,12 +18,14 @@ class MemberConsentEntity (
     @Column(name = "ad_consent", nullable = false)
     val adConsent: Boolean,
 
+    // TODO: 데모데이 이후 val로 변경 예정
     @Column(name = "match_consent", nullable = false)
     var matchConsent: Boolean,
 
     @Column(name = "ad_consented_at")
     val adConsentedAt: LocalDate?,
 
+    // TODO: 데모데이 이후 val로 변경 예정
     @Column(name = "match_consented_at")
     var matchConsentedAt: LocalDate?,
 

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberRepository.kt
@@ -17,4 +17,5 @@ interface MemberRepository : JpaRepository<MemberEntity, String> {
     @Query("SELECT m.role FROM MemberEntity m WHERE m.id = :memberId AND m.deletedAt IS NULL")
     fun findRoleByIdAndDeletedAtIsNull(@Param("memberId") memberId: String): RoleType?
     fun findByIdAndDeletedAtIsNull(memberId: String): MemberEntity?
+    fun findTopByNameOrderByIdDesc(name: String): MemberEntity?
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberConsentGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberConsentGatewayImpl.kt
@@ -2,9 +2,7 @@ package com.dobby.backend.infrastructure.gateway.member
 
 import com.dobby.backend.domain.gateway.member.MemberConsentGateway
 import com.dobby.backend.domain.model.member.MemberConsent
-import com.dobby.backend.domain.model.member.Researcher
 import com.dobby.backend.infrastructure.database.entity.member.MemberConsentEntity
-import com.dobby.backend.infrastructure.database.entity.member.ResearcherEntity
 import com.dobby.backend.infrastructure.database.repository.MemberConsentRepository
 import org.springframework.stereotype.Component
 
@@ -21,5 +19,14 @@ class MemberConsentGatewayImpl(
     override fun findByMemberId(memberId: String): MemberConsent? {
         return memberConsentRepository
                 .findByMemberId(memberId)?.toDomain()
+    }
+
+    override fun updateMatchConsent(memberId: String, matchConsent: Boolean): MemberConsent {
+        val entity = memberConsentRepository.findByMemberId(memberId)
+            ?: throw IllegalArgumentException("MemberConsent not found for memberId: $memberId")
+        entity.matchConsent = matchConsent
+        entity.matchConsentedAt = null
+        val updatedEntity = memberConsentRepository.save(entity)
+        return updatedEntity.toDomain()
     }
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
@@ -59,4 +59,8 @@ class MemberGatewayImpl(
     override fun findRoleByIdAndDeletedAtIsNull(memberId: String): RoleType? {
         return memberRepository.findRoleByIdAndDeletedAtIsNull(memberId)
     }
+
+    override fun findMemberIdByName(name: String): String? {
+        return memberRepository.findTopByNameOrderByIdDesc(name)?.id
+    }
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/SchedulerController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/SchedulerController.kt
@@ -3,9 +3,7 @@ package com.dobby.backend.presentation.api.controller
 import com.dobby.backend.application.service.SchedulerService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @Tag(name = "스케줄러 수동 트리거 API - /v1/scheduler")
 @RestController
@@ -16,9 +14,20 @@ class SchedulerController(
     @GetMapping("/email-trigger")
     @Operation(
         summary = "매칭 공고 이메일 전송 수동 트리거 API",
-        description = "이메일 UT 검증을 위한 테스트 API입니다. 실제 비즈니스 로직이 아니기에, 추후 조정될 여지가 있습니다."
+        description = "데모데이용 테스트 API입니다. 실제 비즈니스 로직이 아니기에, 추후 조정될 여지가 있습니다."
     )
     fun triggerSendMatchingEmailJob() {
         schedulerService.triggerSendMatchingEmailJob()
+    }
+
+    @PutMapping("/member-consent")
+    @Operation(
+        summary = "회원 알림 동의 비활성화 API",
+        description = "데모데이용 테스트 API입니다."
+    )
+    fun updateMemberConsent(
+        @RequestParam memberId: String
+    ) {
+        schedulerService.updateMemberConsent(memberId)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/SchedulerController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/SchedulerController.kt
@@ -26,8 +26,8 @@ class SchedulerController(
         description = "데모데이용 테스트 API입니다."
     )
     fun updateMemberConsent(
-        @RequestParam memberId: String
+        @RequestParam name: String
     ) {
-        schedulerService.updateMemberConsent(memberId)
+        schedulerService.updateMemberConsent(name)
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- 데모데이를 위한 회원 매칭 이메일 동의 여부를 조작하는 API 구현

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 이름을 가지고 update하기에는 혹시 모를 변수때문에 memberId 기준으로 동작하도록 구현했습니다
- 데모데이에만 쓰고 사라질 api라 대충 구현했습니다... 제대로 동작하는지는 api 호출로 체크했습니다


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- 회원 알림 동의 비활성화를 위한 새로운 API 엔드포인트(PUT /member-consent)가 추가되어, 데모데이 테스트 환경에 맞게 기능이 확장되었습니다.
	- 이메일 트리거 API(GET /email-trigger)의 설명이 데모데이용 테스트 API로 업데이트되었습니다.
	- 회원 동의 업데이트 기능을 위한 새로운 메서드가 `SchedulerService`에 추가되었습니다.
	- 회원 ID를 이름으로 검색할 수 있는 기능이 `MemberGateway`에 추가되었습니다.
	- 최신 회원 엔티티를 이름으로 검색할 수 있는 기능이 `MemberRepository`에 추가되었습니다.
  
- **Bug Fixes**
	- `MemberConsentEntity`의 속성이 변경되어 런타임 중 수정 가능하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-345