### PR TITLE
[YS-356] feat: AOP 기반 요청/응답 로깅 적용 및 민감 정보 마스킹 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
 	implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.3")
 	implementation("org.springframework.boot:spring-boot-starter-aop")
 	implementation("ca.pjer:logback-awslogs-appender:1.6.0")
+	implementation("com.aventrix.jnanoid:jnanoid:2.0.0")
 
 	compileOnly("org.projectlombok:lombok")
 	runtimeOnly("com.mysql:mysql-connector-j")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,6 @@ dependencies {
 	implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.3")
 	implementation("org.springframework.boot:spring-boot-starter-aop")
 	implementation("ca.pjer:logback-awslogs-appender:1.6.0")
-	implementation("com.aventrix.jnanoid:jnanoid:2.0.0")
 
 	compileOnly("org.projectlombok:lombok")
 	runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/kotlin/com/dobby/backend/infrastructure/logging/LoggingAspect.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/logging/LoggingAspect.kt
@@ -1,6 +1,6 @@
 package com.dobby.backend.infrastructure.logging
 
-import com.aventrix.jnanoid.jnanoid.NanoIdUtils
+import com.dobby.backend.infrastructure.identifier.TsidIdGenerator
 import org.aspectj.lang.JoinPoint
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.AfterReturning
@@ -15,12 +15,15 @@ import org.springframework.stereotype.Component
 import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.context.request.ServletRequestAttributes
 import java.net.URLDecoder
-import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 @Aspect
 @Component
-class LoggingAspect {
+class LoggingAspect(
+    private val tsidIdGenerator: TsidIdGenerator
+) {
 
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -65,8 +68,9 @@ class LoggingAspect {
      * 타임스탬프 + Nano ID 기반 taskId 생성
      */
     private fun generateTaskId(): String {
-        val timestamp = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(Instant.now())
-        val nanoId = NanoIdUtils.randomNanoId()
-        return "$timestamp-$nanoId"
+        val timestamp = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+            .format(ZonedDateTime.now(ZoneId.of("Asia/Seoul")))
+        val tsid = tsidIdGenerator.generateId()
+        return "$timestamp-$tsid"
     }
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/logging/LoggingAspect.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/logging/LoggingAspect.kt
@@ -1,0 +1,69 @@
+package com.dobby.backend.infrastructure.logging
+
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.AfterReturning
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Pointcut
+import org.aspectj.lang.reflect.MethodSignature
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import java.net.URLDecoder
+import java.util.UUID
+
+@Aspect
+@Component
+class LoggingAspect {
+
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+
+    @Pointcut("execution(* com.dobby.backend.presentation.api.controller..*Controller.*(..))")
+    private fun allController() {}
+
+    @Around("allController()")
+    fun logRequest(joinPoint: ProceedingJoinPoint): Any? {
+        val taskId = UUID.randomUUID().toString().substring(0, 8)
+        setTaskId(taskId)
+
+        val request = (RequestContextHolder.getRequestAttributes() as? ServletRequestAttributes)?.request
+        val method = request?.method ?: "UNKNOWN_METHOD"
+        val requestURI = request?.requestURI ?: "UNKNOWN_URI"
+        val decodedURI = URLDecoder.decode(requestURI, "UTF-8")
+
+        val args = joinPoint.args.map { SensitiveDataMasker.mask(it) }
+
+        log.info("[{}] {} -> {} args={}", taskId, method, decodedURI, args)
+
+        return joinPoint.proceed()
+    }
+
+    @AfterReturning(
+        value = "execution(* com.dobby.backend.presentation.api.controller..*Controller.*(..))",
+        returning = "result"
+    )
+    fun logResponse(joinPoint: JoinPoint, result: Any?) {
+        val taskId = getTaskId() ?: UUID.randomUUID().toString().substring(0, 8)
+        val methodSignature = joinPoint.signature as MethodSignature
+        val controllerMethodName = methodSignature.method.name
+
+        log.info("[{}] <- method: {}, result: {}", taskId, controllerMethodName, SensitiveDataMasker.mask(result))
+    }
+
+    /**
+     * 요청 컨텍스트에 taskId 저장
+     */
+    private fun setTaskId(taskId: String) {
+        RequestContextHolder.getRequestAttributes()?.setAttribute("taskId", taskId, 0)
+    }
+
+    /**
+     * 요청 컨텍스트에서 taskId 가져오기
+     */
+    private fun getTaskId(): String? {
+        return RequestContextHolder.getRequestAttributes()?.getAttribute("taskId", 0) as? String
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/logging/LoggingAspect.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/logging/LoggingAspect.kt
@@ -21,6 +21,7 @@ class LoggingAspect {
 
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
 
+    @Suppress("EmptyFunctionBlock")
     @Pointcut("execution(* com.dobby.backend.presentation.api.controller..*Controller.*(..))")
     private fun allController() {}
 

--- a/src/main/kotlin/com/dobby/backend/infrastructure/logging/LoggingAspect.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/logging/LoggingAspect.kt
@@ -45,11 +45,7 @@ class LoggingAspect(
 
         log.info("[{}] {} -> {} args={}", taskId, method, decodedURI, args)
 
-        try {
-            return joinPoint.proceed()
-        } finally {
-            MDC.remove("taskId") // 요청이 끝난 후 MDC에서 taskId 제거 (메모리 누수 방지)
-        }
+        return joinPoint.proceed()
     }
 
     @AfterReturning(
@@ -62,6 +58,7 @@ class LoggingAspect(
         val controllerMethodName = methodSignature.method.name
 
         log.info("[{}] <- method: {}, result: {}", taskId, controllerMethodName, SensitiveDataMasker.mask(result))
+        MDC.remove("taskId") // 요청이 끝난 후 MDC에서 taskId 제거 (메모리 누수 방지)
     }
 
     /**

--- a/src/main/kotlin/com/dobby/backend/infrastructure/logging/SensitiveDataMasker.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/logging/SensitiveDataMasker.kt
@@ -8,8 +8,10 @@ object SensitiveDataMasker {
     private val objectMapper: ObjectMapper = jacksonObjectMapper()
 
     private val maskPatterns = mapOf(
-        "contactEmail" to "*****",
-        "labInfo" to "*****"
+        "oauthEmail" to { value: String -> value.replaceBefore("@", "*****") },
+        "univEmail" to { value: String -> value.replaceBefore("@", "*****") },
+        "contactEmail" to { value: String -> value.replaceBefore("@", "*****") },
+        "labInfo" to { _: String -> "*****" }
     )
 
     /**
@@ -21,8 +23,10 @@ object SensitiveDataMasker {
         return try {
             val jsonString = objectMapper.writeValueAsString(data)
             var maskedString = jsonString
-            for ((key, mask) in maskPatterns) {
-                maskedString = maskedString.replace(Regex("(?<=\"$key\":\\s?\")[^\"]+"), mask)
+            for ((key, maskFunction) in maskPatterns) {
+                maskedString = maskedString.replace(Regex("(?<=\"$key\":\\s?\")[^\"]+")) {
+                    maskFunction(it.value)
+                }
             }
 
             objectMapper.readValue<Map<String, Any>>(maskedString)

--- a/src/main/kotlin/com/dobby/backend/infrastructure/logging/SensitiveDataMasker.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/logging/SensitiveDataMasker.kt
@@ -7,11 +7,14 @@ import com.fasterxml.jackson.module.kotlin.readValue
 object SensitiveDataMasker {
     private val objectMapper: ObjectMapper = jacksonObjectMapper()
 
-    private val maskPatterns = mapOf(
-        "oauthEmail" to { value: String -> value.replaceBefore("@", "*****") },
-        "univEmail" to { value: String -> value.replaceBefore("@", "*****") },
-        "contactEmail" to { value: String -> value.replaceBefore("@", "*****") },
-        "labInfo" to { _: String -> "*****" }
+    private val maskPatterns: Map<String, (String) -> String> = mapOf(
+        "name" to { value -> value.take(1) + "*****" },
+        "oauthEmail" to { value -> value.first() + "*****@" + value.substringAfter("@") },
+        "univEmail" to { value -> value.first() + "*****@" + value.substringAfter("@") },
+        "contactEmail" to { value -> value.first() + "*****@" + value.substringAfter("@") },
+        "univName" to { value -> value.take(1) + "*******" },
+        "major" to { value -> value.take(1) + "********" },
+        "labInfo" to { _ -> "*****" }
     )
 
     /**
@@ -31,7 +34,7 @@ object SensitiveDataMasker {
 
             objectMapper.readValue<Map<String, Any>>(maskedString)
         } catch (e: Exception) {
-            maskPatterns.mapValues { it.value }
+            maskPatterns.mapValues { it.value("*****") }
         }
     }
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/logging/SensitiveDataMasker.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/logging/SensitiveDataMasker.kt
@@ -1,0 +1,33 @@
+package com.dobby.backend.infrastructure.logging
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+object SensitiveDataMasker {
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+
+    private val maskPatterns = mapOf(
+        "contactEmail" to "*****",
+        "labInfo" to "*****"
+    )
+
+    /**
+     * 특정 키워드가 포함된 민감 정보를 마스킹 처리
+     */
+    fun mask(data: Any?): Any? {
+        if (data == null) return null
+
+        return try {
+            val jsonString = objectMapper.writeValueAsString(data)
+            var maskedString = jsonString
+            for ((key, mask) in maskPatterns) {
+                maskedString = maskedString.replace(Regex("(?<=\"$key\":\\s?\")[^\"]+"), mask)
+            }
+
+            objectMapper.readValue<Map<String, Any>>(maskedString)
+        } catch (e: Exception) {
+            maskPatterns.mapValues { it.value }
+        }
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -30,7 +30,7 @@
             <maxBatchLogEvents>50</maxBatchLogEvents>
             <maxFlushTimeMillis>30000</maxFlushTimeMillis>
             <maxBlockTimeMillis>5000</maxBlockTimeMillis>
-            <retentionTimeDays>0</retentionTimeDays>
+            <retentionTimeDays>7</retentionTimeDays>
             <accessKeyId>${AWS_ACCESS_KEY_ID}</accessKeyId>
             <secretAccessKey>${AWS_SECRET_ACCESS_KEY}</secretAccessKey>
         </appender>
@@ -53,7 +53,7 @@
             <maxBatchLogEvents>50</maxBatchLogEvents>
             <maxFlushTimeMillis>30000</maxFlushTimeMillis>
             <maxBlockTimeMillis>5000</maxBlockTimeMillis>
-            <retentionTimeDays>0</retentionTimeDays>
+            <retentionTimeDays>7</retentionTimeDays>
             <accessKeyId>${AWS_ACCESS_KEY_ID}</accessKeyId>
             <secretAccessKey>${AWS_SECRET_ACCESS_KEY}</secretAccessKey>
         </appender>


### PR DESCRIPTION
## 💡 작업 내용
- AOP 기반의 요청/응답 로깅 기능 적용
  - 각 요청마다 고유한 taskId 부여하여 추적 가능하도록 개선
  - contactEmail, labInfo 등 민감 정보 자동 마스킹 처리
- CloudWatch retention 기간 7일로 변경

**요청/응답 로그**
<img width="400" alt="스크린샷 2025-02-24 오후 12 50 19" src="https://github.com/user-attachments/assets/6f616655-b41a-46c3-b5ed-701de4a99cce" />
<img width="400" alt="스크린샷 2025-02-24 오후 12 50 25" src="https://github.com/user-attachments/assets/19bb3eac-9894-469e-af61-bbd45d7ebdcd" />

**민감 정보 마스킹**
<img width="400" alt="스크린샷 2025-02-24 오후 1 13 10" src="https://github.com/user-attachments/assets/0b4e8ecc-461c-4799-b76d-4ec04b5c2e0c" />


## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 현재 개발/운영 환경의 로그는 CloudWatch에 저장되는데 이메일, 이름 등 개인 식별이 가능한 정보가 포함될 수 있어 보안 리스크가 존재한다고 판단했습니다. 이를 방지하기 위해 중요한 민감 정보는 마스킹 처리하여 저장하고, 디버깅이 필요한 최소한의 정보만 남기도록 했습니다.


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - API 요청 및 응답에 대한 로깅 기능이 추가되어, 각 요청에 고유한 식별자가 부여되고 민감 정보는 자동으로 보호됩니다.
- **Chores**
  - 로그 보존 기간이 개발 및 운영 환경 모두에서 0일에서 7일로 업데이트되어, 로그 기록 관리가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
