### PR TITLE
[YS-352] refactor: 학교 메일 인증을 완료했으나 회원가입을 마치지 않은 사용자를 구분하는 로직 추가

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/email/SendEmailCodeUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/email/SendEmailCodeUseCase.kt
@@ -11,6 +11,7 @@ import com.dobby.backend.domain.gateway.email.EmailGateway
 import com.dobby.backend.domain.gateway.email.VerificationGateway
 import com.dobby.backend.domain.model.Verification
 import com.dobby.backend.domain.enums.VerificationStatus
+import com.dobby.backend.domain.gateway.member.ResearcherGateway
 import com.dobby.backend.util.EmailUtils
 import com.dobby.backend.util.RetryUtils
 import kotlinx.coroutines.CoroutineScope
@@ -18,6 +19,7 @@ import kotlinx.coroutines.launch
 
 class SendEmailCodeUseCase(
     private val verificationGateway: VerificationGateway,
+    private val researcherGateway: ResearcherGateway,
     private val emailGateway: EmailGateway,
     private val cacheGateway: CacheGateway,
     private val idGenerator: IdGenerator,
@@ -39,7 +41,7 @@ class SendEmailCodeUseCase(
         val requestCountKey = "request_count:${input.univEmail}"
         val currentCount = cacheGateway.get(requestCountKey)?.toIntOrNull() ?: 0
         if(currentCount >= 3) {
-            throw TooManyVerificationRequestException
+            //throw TooManyVerificationRequestException
         }
 
         cacheGateway.incrementRequestCount(requestCountKey)
@@ -63,6 +65,8 @@ class SendEmailCodeUseCase(
     private fun validateEmail(email : String){
         if(!EmailUtils.isDomainExists(email)) throw EmailDomainNotFoundException
         if(!EmailUtils.isUnivMail(email)) throw EmailNotUnivException
+        if (researcherGateway.existsByUnivEmail(email))
+            throw SignupUnivEmailDuplicateException
         if(verificationGateway.findByUnivEmailAndStatus(email, VerificationStatus.VERIFIED) != null)
             throw EmailAlreadyVerifiedException
     }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/email/SendEmailCodeUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/email/SendEmailCodeUseCase.kt
@@ -41,7 +41,7 @@ class SendEmailCodeUseCase(
         val requestCountKey = "request_count:${input.univEmail}"
         val currentCount = cacheGateway.get(requestCountKey)?.toIntOrNull() ?: 0
         if(currentCount >= 3) {
-            //throw TooManyVerificationRequestException
+            throw TooManyVerificationRequestException
         }
 
         cacheGateway.incrementRequestCount(requestCountKey)

--- a/src/main/kotlin/com/dobby/backend/domain/exception/DobbyException.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/exception/DobbyException.kt
@@ -40,7 +40,7 @@ data object VerifyInfoNotFoundException : ClientException("VE0003", "Verificatio
 data object CodeNotCorrectException : ClientException("VE0004", "Verification code is not correct", HttpStatus.BAD_REQUEST)
 data object CodeExpiredException : ClientException("VE0005", "Verification code is expired", HttpStatus.BAD_REQUEST)
 data object EmailFormatInvalidException : ClientException("VE0006", "Email is invalid format", HttpStatus.BAD_REQUEST)
-data object EmailAlreadyVerifiedException : ClientException("VE0007", "This email is already verified", HttpStatus.CONFLICT)
+data object EmailAlreadyVerifiedException : ClientException("VE0007", "This email is already verified. All you have to do is just completing the signup.", HttpStatus.CONFLICT)
 data object TooManyVerificationRequestException : ClientException("VE0008", "You can request verification up to 3 in one day.", HttpStatus.TOO_MANY_REQUESTS)
 
 /**
@@ -54,6 +54,7 @@ data object EmailNotValidateException : ClientException("ME0005", "You should va
 data object SignupOauthEmailDuplicateException : ClientException("ME0006", "You've already joined with requested oauth email", HttpStatus.CONFLICT)
 data object ContactEmailDuplicateException: ClientException("ME0007", "This contact email is already in use.", HttpStatus.CONFLICT)
 data object MemberConsentNotFoundException : ClientException("ME0008", "Member Consent Not Found.", HttpStatus.NOT_FOUND)
+data object SignupUnivEmailDuplicateException: ClientException("ME009", "You've already joined with requested univ email", HttpStatus.CONFLICT)
 
 /**
  * Experiment error codes

--- a/src/main/kotlin/com/dobby/backend/domain/exception/DobbyException.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/exception/DobbyException.kt
@@ -54,7 +54,7 @@ data object EmailNotValidateException : ClientException("ME0005", "You should va
 data object SignupOauthEmailDuplicateException : ClientException("ME0006", "You've already joined with requested oauth email", HttpStatus.CONFLICT)
 data object ContactEmailDuplicateException: ClientException("ME0007", "This contact email is already in use.", HttpStatus.CONFLICT)
 data object MemberConsentNotFoundException : ClientException("ME0008", "Member Consent Not Found.", HttpStatus.NOT_FOUND)
-data object SignupUnivEmailDuplicateException: ClientException("ME009", "You've already joined with requested univ email", HttpStatus.CONFLICT)
+data object SignupUnivEmailDuplicateException: ClientException("ME0009", "You've already joined with requested univ email", HttpStatus.CONFLICT)
 
 /**
  * Experiment error codes

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/member/ResearcherGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/member/ResearcherGateway.kt
@@ -5,6 +5,6 @@ import com.dobby.backend.domain.model.member.Researcher
 interface ResearcherGateway {
     fun findByMemberId(memberId: String): Researcher?
     fun findByMemberIdAndMemberDeletedAtIsNull(memberId: String): Researcher?
-
+    fun existsByUnivEmail(univEmail: String): Boolean
     fun save(researcher: Researcher): Researcher
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ResearcherRepository.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ResearcherRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface ResearcherRepository: JpaRepository<ResearcherEntity, String> {
     fun findByMemberId(memberId: String) : ResearcherEntity?
     fun findByMemberIdAndMemberDeletedAtIsNull(memberId: String): ResearcherEntity?
+    fun existsByUnivEmail(univEmail: String): Boolean
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/ResearcherGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/ResearcherGatewayImpl.kt
@@ -28,4 +28,8 @@ class ResearcherGatewayImpl(
             .save(ResearcherEntity.fromDomain(researcher))
         return savedEntity.toDomain()
     }
+
+    override fun existsByUnivEmail(univEmail: String): Boolean {
+        return researcherRepository.existsByUnivEmail(univEmail)
+    }
 }

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/email/SendEmailCodeUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/email/SendEmailCodeUseCaseTest.kt
@@ -3,12 +3,13 @@ package com.dobby.backend.application.usecase.member.email
 import com.dobby.backend.application.common.CoroutineDispatcherProvider
 import com.dobby.backend.application.common.TransactionExecutor
 import com.dobby.backend.domain.EmailTemplateLoader
-import com.dobby.backend.domain.exception.EmailDomainNotFoundException
-import com.dobby.backend.domain.exception.EmailNotUnivException
 import com.dobby.backend.domain.IdGenerator
+import com.dobby.backend.domain.enums.VerificationStatus
+import com.dobby.backend.domain.exception.*
 import com.dobby.backend.domain.gateway.CacheGateway
 import com.dobby.backend.domain.gateway.email.EmailGateway
 import com.dobby.backend.domain.gateway.email.VerificationGateway
+import com.dobby.backend.domain.gateway.member.ResearcherGateway
 import com.dobby.backend.util.EmailUtils
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -18,6 +19,7 @@ import kotlinx.coroutines.test.runTest
 class SendEmailCodeUseCaseTest : BehaviorSpec({
 
     val verificationGateway: VerificationGateway = mockk(relaxed = true)
+    val researcherGateway: ResearcherGateway = mockk(relaxed = true)
     val emailGateway: EmailGateway = mockk(relaxed = true)
     val cacheGateway: CacheGateway = mockk(relaxed = true)
     val idGenerator: IdGenerator = mockk(relaxed = true)
@@ -25,10 +27,14 @@ class SendEmailCodeUseCaseTest : BehaviorSpec({
     val transactionExecutor: TransactionExecutor = mockk(relaxed = true)
     val emailTemplateLoader: EmailTemplateLoader = mockk(relaxed = true)
 
-    val sendEmailCodeUseCase = SendEmailCodeUseCase(verificationGateway, emailGateway, cacheGateway, idGenerator, dispatcherProvider, transactionExecutor, emailTemplateLoader)
+    val sendEmailCodeUseCase = SendEmailCodeUseCase(verificationGateway, researcherGateway, emailGateway, cacheGateway, idGenerator, dispatcherProvider, transactionExecutor, emailTemplateLoader)
 
     beforeSpec {
         mockkObject(EmailUtils)
+    }
+
+    afterSpec {
+        unmockkObject(EmailUtils)
     }
 
     given("유효하지 않은 도메인의 이메일이 주어졌을 때") {
@@ -56,6 +62,41 @@ class SendEmailCodeUseCaseTest : BehaviorSpec({
                 runTest {
                     shouldThrow<EmailNotUnivException> {
                         sendEmailCodeUseCase.execute(SendEmailCodeUseCase.Input(personalEmail))
+                    }
+                }
+            }
+        }
+    }
+
+    given("이미 가입된 대학 이메일이 주어졌을 때") {
+        val duplicateEmail = "christer10@ewhain.net"
+        every { EmailUtils.isDomainExists(duplicateEmail) } returns true
+        every { EmailUtils.isUnivMail(duplicateEmail) } returns true
+        every { researcherGateway.existsByUnivEmail(duplicateEmail) } returns true
+
+        `when`("이메일 인증 코드 전송을 실행하면") {
+            then("SignupUnivEmailDuplicateException 예외가 발생해야 한다") {
+                runTest {
+                    shouldThrow<SignupUnivEmailDuplicateException> {
+                        sendEmailCodeUseCase.execute(SendEmailCodeUseCase.Input(duplicateEmail))
+                    }
+                }
+            }
+        }
+    }
+
+    given("회원가입은 완료하지 않았지만, 이미 인증된 대학 이메일이 주어졌을 때") {
+        val verifiedEmail = "verified@ewhain.net"
+        every { EmailUtils.isDomainExists(verifiedEmail) } returns true
+        every { EmailUtils.isUnivMail(verifiedEmail) } returns true
+        every { researcherGateway.existsByUnivEmail(verifiedEmail) } returns false
+        every { verificationGateway.findByUnivEmailAndStatus(verifiedEmail, VerificationStatus.VERIFIED) } returns mockk()
+
+        `when`("이메일 인증 코드 전송을 실행하면") {
+            then("EmailAlreadyVerifiedException 예외가 발생해야 한다") {
+                runTest {
+                    shouldThrow<EmailAlreadyVerifiedException> {
+                        sendEmailCodeUseCase.execute(SendEmailCodeUseCase.Input(verifiedEmail))
                     }
                 }
             }

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/email/SendEmailCodeUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/email/SendEmailCodeUseCaseTest.kt
@@ -102,6 +102,25 @@ class SendEmailCodeUseCaseTest : BehaviorSpec({
             }
         }
     }
+
+    given("이메일 인증 코드 요청 횟수가 초과된 경우") {
+        val limitedEmail = "limited@ewhain.net"
+        every { EmailUtils.isDomainExists(limitedEmail) } returns true
+        every { EmailUtils.isUnivMail(limitedEmail) } returns true
+        every { researcherGateway.existsByUnivEmail(limitedEmail) } returns false
+        every { verificationGateway.findByUnivEmailAndStatus(limitedEmail, VerificationStatus.VERIFIED) } returns null
+        every { cacheGateway.get("request_count:$limitedEmail") } returns "3"
+
+        `when`("이메일 인증 코드 전송을 실행하면") {
+            then("TooManyVerificationRequestException 예외가 발생해야 한다") {
+                runTest {
+                    shouldThrow<TooManyVerificationRequestException> {
+                        sendEmailCodeUseCase.execute(SendEmailCodeUseCase.Input(limitedEmail))
+                    }
+                }
+            }
+        }
+    }
 })
 
 


### PR DESCRIPTION
## 💡 작업 내용
- 이메일 인증을 완료했지만 회원가입을 완료하지 않은 사용자를 식별하는 로직 추가
- 커스텀 예외 로직 추가하여 이미 회원가입을 완료한 `univEmail` 의 케이스인지 / 회원가입이 완료되지 않고 이메일 인증만 완료한 케이스인지 구별
- 관련 테스트 코드 케이스 추가 

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 존재하는 회원의 `univEmail` 로 인증 시도할 경우 예외 반환

![이메일 인증(이미 존재)](https://github.com/user-attachments/assets/5fbc92a7-61e4-449b-b5dd-361eea8feb24)
- 인증은 완료했으나, 회원가입을 완료하지 않았을 때 인증 시도할 경우 예외 반환

![이메일 인증(아직 회원가입 x)](https://github.com/user-attachments/assets/be8e55a5-537a-4ccc-9d81-bd1792f7f3e7)


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 이메일 인증 과정에 중복된 대학 이메일 사용 검증을 추가하여, 이미 등록된 이메일로 가입 시 명확한 오류 메시지가 제공됩니다.
  - 이미 인증된 이메일에 대한 안내 메시지가 개선되어 사용자에게 보다 친절한 정보를 전달합니다.

- **테스트**
  - 이메일 인증 시나리오에 중복 및 이미 인증된 이메일 처리 케이스가 추가되어 기능 안정성이 강화되었습니다.
  - 이메일 인증 요청 수 초과 시 처리 케이스가 추가되어 오류 처리 능력이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->