### PR TITLE
[YS-360] fix: 모집완료된 공고에 대해서는 매칭 공고 알림이 안 가도록 처리

### DIFF
--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepositoryImpl.kt
@@ -214,8 +214,6 @@ class ExperimentPostCustomRepositoryImpl (
         entityManager.merge(experimentPost)
     }
 
-    private var lastProcessedTime: LocalDateTime = LocalDate.now().minusDays(1).atTime(8, 1)
-
     override fun findMatchingExperimentPostsForAllParticipants(): Map<String, List<ExperimentPostEntity>> {
         val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -223,16 +221,18 @@ class ExperimentPostCustomRepositoryImpl (
         val targetGroup = QTargetGroupEntity.targetGroupEntity
         val participant = QParticipantEntity.participantEntity
         val member = QMemberEntity.memberEntity
-       val memberConsent = QMemberConsentEntity.memberConsentEntity
+        val memberConsent = QMemberConsentEntity.memberConsentEntity
 
         val currentTime = LocalDateTime.now()
+        val lastProcessedTime: LocalDateTime = LocalDate.now().minusDays(1).atTime(8, 1)
 
         logger.info("[쿼리 범위] lastProcessedTime: {}, currentTime: {}", lastProcessedTime, currentTime)
         val todayPosts = jpaQueryFactory.selectFrom(experimentPost)
             .join(experimentPost.targetGroup, targetGroup).fetchJoin()
             .where(
                 experimentPost.createdAt.between(lastProcessedTime, currentTime),
-                experimentPost.alarmAgree.isTrue
+                experimentPost.alarmAgree.isTrue,
+                experimentPost.recruitStatus.isTrue
             )
             .fetch()
 


### PR DESCRIPTION
## 💡 작업 내용
- 버그 사항을 발견하여 수정합니다.
   - 기존 `lastProcessedTime` : "직전에 해당 Job이 실행된 시각" → 수정: 기획 요구사항에 맞게, '전날 08:01' 을 기준으로 수정
   - 현재 모집 중(recruitStatus = true) 인 공고에 대해서만 알림 보내도록 로직 수정 

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 실험 게시물 필터 기준을 개선하여, 알람 동의와 모집 상태 조건을 모두 충족하는 게시물만 사용자에게 표시되도록 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->