### PR TITLE
[YS-401] chore: GitHub Actions 워크플로우에 ktlint 코드 품질 검사 추가

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -1,9 +1,6 @@
 name: Java CI with Gradle
 
 on:
-  push:
-    branches:
-      - dev
   pull_request:
     branches:
       - dev

--- a/.github/workflows/ktlint-check.yml
+++ b/.github/workflows/ktlint-check.yml
@@ -16,7 +16,7 @@ jobs:
               with:
                   fetch-depth: 1
             - name: ktlint
-              uses: ScaCap/action-ktlint@v2
+              uses: ScaCap/action-ktlint@master
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   reporter: github-pr-check

--- a/.github/workflows/ktlint-check.yml
+++ b/.github/workflows/ktlint-check.yml
@@ -12,7 +12,7 @@ jobs:
 
         steps:
             - name: Clone repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   fetch-depth: 1
             - name: ktlint

--- a/.github/workflows/ktlint-check.yml
+++ b/.github/workflows/ktlint-check.yml
@@ -1,0 +1,22 @@
+name: ktlint-code-quality-check
+
+on:
+    pull_request:
+        branches:
+            - dev
+
+jobs:
+    ktlint:
+        name: Check Code Quality
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Clone repo
+              uses: actions/checkout@v2
+              with:
+                  fetch-depth: 1
+            - name: ktlint
+              uses: ScaCap/action-ktlint@v2
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  reporter: github-pr-check


### PR DESCRIPTION
## 💡 작업 내용
- GitHub Actions 워크플로우에 ktlint 코드 품질 검사 추가
- 기존 CI 파일에서 dev 브랜치에 대한 push 트리거 제거

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- dev 브랜치에 머지될 때, CI가 두 번 돌아가서 한 번만 동작하도록 `ci-dev.yml`에서 dev 브랜치에 대한 push 트리거를 제거했습니다
<img width="400" alt="스크린샷 2025-03-30 오후 5 34 14" src="https://github.com/user-attachments/assets/23a83496-ecaa-4796-9191-84e1f1ed74b1" />



## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - CI/CD 자동 실행 조건을 개선하여, 직접 푸시 시 불필요한 실행을 줄였습니다.
- **New Features**
  - 풀 리퀘스트 기반의 자동 코드 품질 및 스타일 검사 기능을 도입했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
