### PR TITLE
[YS-415] feature: 연구자 회원 가입 - 인증 번호 메일 전송 시, 요청 횟수 반환 추가

### DIFF
--- a/application/src/main/kotlin/com/dobby/usecase/member/email/SendEmailCodeUseCase.kt
+++ b/application/src/main/kotlin/com/dobby/usecase/member/email/SendEmailCodeUseCase.kt
@@ -32,7 +32,7 @@ class SendEmailCodeUseCase(
     data class Output(
         val isSuccess: Boolean,
         val message: String,
-        val requestCount: Int
+        val requestCount: Int,
     )
     override fun execute(input: Input): Output {
         validateEmail(input.univEmail)
@@ -54,7 +54,7 @@ class SendEmailCodeUseCase(
         return Output(
             isSuccess = true,
             message = "학교 이메일로 코드가 전송되었습니다. 10분 이내로 인증을 완료해주세요.",
-            requestCount = cacheGateway.get(requestCountKey)?.toIntOrNull() ?: 0
+            requestCount = cacheGateway.get(requestCountKey)?.toIntOrNull() ?: 0,
         )
     }
 

--- a/application/src/main/kotlin/com/dobby/usecase/member/email/SendEmailCodeUseCase.kt
+++ b/application/src/main/kotlin/com/dobby/usecase/member/email/SendEmailCodeUseCase.kt
@@ -31,7 +31,8 @@ class SendEmailCodeUseCase(
     )
     data class Output(
         val isSuccess: Boolean,
-        val message: String
+        val message: String,
+        val requestCount: Int
     )
     override fun execute(input: Input): Output {
         validateEmail(input.univEmail)
@@ -52,7 +53,8 @@ class SendEmailCodeUseCase(
 
         return Output(
             isSuccess = true,
-            message = "학교 이메일로 코드가 전송되었습니다. 10분 이내로 인증을 완료해주세요."
+            message = "학교 이메일로 코드가 전송되었습니다. 10분 이내로 인증을 완료해주세요.",
+            requestCount = cacheGateway.get(requestCountKey)?.toIntOrNull() ?: 0
         )
     }
 

--- a/presentation/src/main/kotlin/com/dobby/api/dto/response/member/EmailSendResponse.kt
+++ b/presentation/src/main/kotlin/com/dobby/api/dto/response/member/EmailSendResponse.kt
@@ -7,5 +7,8 @@ data class EmailSendResponse(
     val isSuccess: Boolean,
 
     @Schema(description = "반환 성공 메시지 입니다.")
-    val message: String
+    val message: String,
+
+    @Schema(description = "하루 이메일 전송 코드 요청 횟수 입니다.")
+    val requestCount: Int
 )

--- a/presentation/src/main/kotlin/com/dobby/api/dto/response/member/EmailSendResponse.kt
+++ b/presentation/src/main/kotlin/com/dobby/api/dto/response/member/EmailSendResponse.kt
@@ -5,10 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class EmailSendResponse(
     @Schema(description = "학교 이메일 인증을 성공하여, 코드를 성공적으로 전송했는지 여부입니다.")
     val isSuccess: Boolean,
-
     @Schema(description = "반환 성공 메시지 입니다.")
     val message: String,
-
     @Schema(description = "하루 이메일 전송 코드 요청 횟수 입니다.")
-    val requestCount: Int
+    val requestCount: Int,
 )

--- a/presentation/src/main/kotlin/com/dobby/api/mapper/EmailMapper.kt
+++ b/presentation/src/main/kotlin/com/dobby/api/mapper/EmailMapper.kt
@@ -19,7 +19,7 @@ object EmailMapper {
         return EmailSendResponse(
             isSuccess = output.isSuccess,
             message = output.message,
-            requestCount = output.requestCount
+            requestCount = output.requestCount,
         )
     }
 

--- a/presentation/src/main/kotlin/com/dobby/api/mapper/EmailMapper.kt
+++ b/presentation/src/main/kotlin/com/dobby/api/mapper/EmailMapper.kt
@@ -18,7 +18,8 @@ object EmailMapper {
     fun toEmailSendResponse(output: SendEmailCodeUseCase.Output): EmailSendResponse {
         return EmailSendResponse(
             isSuccess = output.isSuccess,
-            message = output.message
+            message = output.message,
+            requestCount = output.requestCount
         )
     }
 


### PR DESCRIPTION
## 💡 작업 내용
- 2025.04.19 일자 디스코드에서 논의한 내용에 따라 메일 요청 API (`/emails/send`) 반환 값에 `requestCount` 필드를 추가합니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 이메일 인증 코드 요청 시, 해당 이메일로 하루 동안 요청한 횟수(requestCount)가 응답에 포함되어 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-415