### PR TITLE
[YS-418] fix: 연구자 회원가입 이메일 인증 완료 시, 누락된 인증 요청 횟수 초기화 로직 추가

### DIFF
--- a/application/src/main/kotlin/com/dobby/usecase/member/email/VerifyEmailUseCase.kt
+++ b/application/src/main/kotlin/com/dobby/usecase/member/email/VerifyEmailUseCase.kt
@@ -43,6 +43,7 @@ class VerifyEmailUseCase(
         verificationGateway.save(updatedVerification)
 
         cacheGateway.evict("verification:${input.univEmail}")
+        cacheGateway.evict("request_count:${input.univEmail}")
 
         return Output(
             isSuccess = true,


### PR DESCRIPTION
## 💡 작업 내용
- **2025.04.20 디스코드에서 논의된 사항을 반영**합니다.
![image](https://github.com/user-attachments/assets/6d4c25f1-22fd-4c47-b338-f6d4ae0ef5f9)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 이메일 인증 성공 시, 인증 코드와 함께 요청 횟수 캐시도 함께 삭제되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->