### PR TITLE
[YS-457] hotfix: ktlint 버전 문제로 gradle ktlintCheck 방식으로 변경

### DIFF
--- a/.github/workflows/ktlint-check.yml
+++ b/.github/workflows/ktlint-check.yml
@@ -14,9 +14,16 @@ jobs:
             - name: Clone repo
               uses: actions/checkout@v3
               with:
-                  fetch-depth: 1
-            - name: ktlint
-              uses: ScaCap/action-ktlint@master
+                fetch-depth: 1
+
+            - name: Set up JDK 17
+              uses: actions/setup-java@v4
               with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
-                  reporter: github-pr-check
+                java-version: '17'
+                distribution: 'temurin'
+
+            - name: Grant execute permission for gradlew
+              run: chmod +x gradlew
+
+            - name: Run ktlint via Gradle
+              run: ./gradlew ktlintCheck


### PR DESCRIPTION
## 💡 작업 내용
- ktlint 버전 문제로 gradle ktlintCheck 방식으로 변경

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- ktlint 버전 차이로 로컬과 GitHub 측정 결과가 일치하지 않는 문제가 발생하여, hotfix로 우선 머지하겠습니다


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-457