### PR TITLE
[YS-503] 연구자 회원가입 시 해외 학교 도메인도 허용하도록 수정

### DIFF
--- a/application/src/main/kotlin/com/dobby/util/EmailUtils.kt
+++ b/application/src/main/kotlin/com/dobby/util/EmailUtils.kt
@@ -25,15 +25,16 @@ object EmailUtils {
     }
 
     fun isUnivMail(email: String): Boolean {
-        val eduDomains = setOf(
-            "postech.edu",
-            "kaist.edu",
-            "handong.edu",
+        val univDomainExcpetions = setOf(
             "ewhain.net",
-            "g.skku.edu"
         )
-        return email.endsWith(".ac.kr") || eduDomains.any { email.endsWith(it) }
+        return email.endsWith(".ac.kr") ||
+            email.endsWith(".edu") ||
+            email.endsWith("edu.uk") ||
+            email.endsWith(".edu.au") ||
+            univDomainExcpetions.any { email.endsWith(it) }
     }
+
     fun generateCode(): String {
         val randomNum = (0..999999).random()
         return String.format("%06d", randomNum)


### PR DESCRIPTION
## 💡 작업 내용
- 국내 대학교 이메일 표준 도메인("`.ac.kr`") 뿐만 아니라 미국, 영국, 호주 대학교 표준 이메일 도메인까지 허용 가능하도록 밸리데이션 로직을 소소하게 수정해봤습니다. ㅎㅎ

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요
