### PR TITLE
[RELEASE] 릴리즈 v1.1.5

### DIFF
--- a/application/src/main/kotlin/com/dobby/util/EmailUtils.kt
+++ b/application/src/main/kotlin/com/dobby/util/EmailUtils.kt
@@ -25,15 +25,16 @@ object EmailUtils {
     }
 
     fun isUnivMail(email: String): Boolean {
-        val eduDomains = setOf(
-            "postech.edu",
-            "kaist.edu",
-            "handong.edu",
-            "ewhain.net",
-            "g.skku.edu"
+        val univDomainExcpetions = setOf(
+            "ewhain.net"
         )
-        return email.endsWith(".ac.kr") || eduDomains.any { email.endsWith(it) }
+        return email.endsWith(".ac.kr") ||
+            email.endsWith(".edu") ||
+            email.endsWith("ac.uk") ||
+            email.endsWith(".edu.au") ||
+            univDomainExcpetions.any { email.endsWith(it) }
     }
+
     fun generateCode(): String {
         val randomNum = (0..999999).random()
         return String.format("%06d", randomNum)

--- a/application/src/test/kotlin/com/dobby/usecase/member/email/SendEmailCodeUseCaseTest.kt
+++ b/application/src/test/kotlin/com/dobby/usecase/member/email/SendEmailCodeUseCaseTest.kt
@@ -15,10 +15,13 @@ import com.dobby.util.EmailUtils
 import com.dobby.util.IdGenerator
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
+import kotlinx.coroutines.test.runTest
 
 class SendEmailCodeUseCaseTest : BehaviorSpec({
 
@@ -61,6 +64,28 @@ class SendEmailCodeUseCaseTest : BehaviorSpec({
             then("EmailNotUnivException 예외가 발생해야 한다") {
                 shouldThrow<EmailNotUnivException> {
                     sendEmailCodeUseCase.execute(SendEmailCodeUseCase.Input(personalEmail))
+                }
+            }
+        }
+    }
+
+    given("해외 대학 이메일 도메인이 주어졌을 때") {
+        val overseasEmail = "dobby-socks@griffithuni.edu.au"
+        every { EmailUtils.isDomainExists(overseasEmail) } returns true
+        every { EmailUtils.isUnivMail(overseasEmail) } returns true
+        every { researcherGateway.existsByUnivEmail(overseasEmail) } returns false
+        every { verificationGateway.findByUnivEmailAndStatus(overseasEmail, VerificationStatus.VERIFIED) } returns null
+        every { cacheGateway.get("request_count:$overseasEmail") } returns null
+
+        `when`("이메일 인증 코드 전송을 실행하면") {
+            then("예외 없이 정상 동작해야 한다") {
+                runTest {
+                    val input = SendEmailCodeUseCase.Input(overseasEmail)
+                    val output = sendEmailCodeUseCase.execute(input)
+                    output.isSuccess shouldBe true
+                    coVerify(exactly = 1) {
+                        emailGateway.sendEmail(overseasEmail, any(), any(), true)
+                    }
                 }
             }
         }

--- a/application/src/test/kotlin/com/dobby/usecase/member/email/SendMatchingEmailUseCaseTest.kt
+++ b/application/src/test/kotlin/com/dobby/usecase/member/email/SendMatchingEmailUseCaseTest.kt
@@ -18,14 +18,18 @@ import com.dobby.model.experiment.ApplyMethod
 import com.dobby.model.experiment.ExperimentPost
 import com.dobby.model.experiment.TargetGroup
 import com.dobby.model.member.Member
+import com.dobby.util.EmailUtils
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import java.time.LocalDate
@@ -39,6 +43,14 @@ class SendMatchingEmailUseCaseTest : BehaviorSpec({
     val memberConsentGateway = mockk<MemberConsentGateway>(relaxed = true)
     val emailTemplateLoader = mockk<EmailTemplateLoader>(relaxed = true)
     val sendMatchingEmailUseCase = SendMatchingEmailUseCase(emailGateway, urlGeneratorGateway, memberGateway, memberConsentGateway, emailTemplateLoader)
+
+    beforeSpec {
+        mockkObject(EmailUtils)
+    }
+
+    afterSpec {
+        unmockkObject(EmailUtils)
+    }
 
     given("이메일 매칭 발송을 실행할 때") {
 
@@ -164,6 +176,7 @@ class SendMatchingEmailUseCaseTest : BehaviorSpec({
                 )
             )
             val input = SendMatchingEmailUseCase.Input(invalidEmail, experimentPosts, LocalDateTime.now())
+            every { EmailUtils.isDomainExists(invalidEmail) } returns false
 
             then("EmailDomainNotFoundException 예외가 발생해야 한다") {
                 runTest {


### PR DESCRIPTION
* feature: add overseas univ email domain to meet the scalability

* test: add test case for overseas university domain to successfully code sent

* fix: isolate EmailUtils mock to prevent global state pollution

- 로컬에서 통과하는데 CI에서는 꺠지는 테스트 케이스
- unmock없이 EmailUtils 가 공유되는 현상이라고 추측하여 해당 커밋에 반영해봄.

* refactor: make correct to uk university email domain

* fix: remove wildcard imports to comply with ktlint rules

## 💡 작업 내용
- 해외 학교 이메일 도메인 허용 -> 금주 내 반영 예정인 요구사항이므로 일단 운영에 나가는 걸로 판단하겠습니다.
- 논의되었던 추가개발 내용 (학교명 자동완성 API나 교내 실험 여부 등)은 다음 릴리즈 때 포함하겠습니다. ㅎㅎ

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요
