### PR TITLE
[YS-506] refactor: 자동완성 API - 동일 요청에 대한 캐싱 처리로 리팩토링

### DIFF
--- a/application/src/main/kotlin/com/dobby/usecase/member/SearchUniversityAutoCompleteUseCase.kt
+++ b/application/src/main/kotlin/com/dobby/usecase/member/SearchUniversityAutoCompleteUseCase.kt
@@ -1,9 +1,12 @@
 package com.dobby.usecase.member
 
 import com.dobby.enums.University
+import com.dobby.gateway.CacheGateway
 import com.dobby.usecase.UseCase
 
-class SearchUniversityAutoCompleteUseCase() : UseCase<SearchUniversityAutoCompleteUseCase.Input, SearchUniversityAutoCompleteUseCase.Output> {
+class SearchUniversityAutoCompleteUseCase(
+    private val cacheGateway: CacheGateway
+) : UseCase<SearchUniversityAutoCompleteUseCase.Input, SearchUniversityAutoCompleteUseCase.Output> {
 
     data class Input(
         val query: String
@@ -14,8 +17,29 @@ class SearchUniversityAutoCompleteUseCase() : UseCase<SearchUniversityAutoComple
     )
 
     override fun execute(input: Input): Output {
+        val cleanedQuery = input.query.clean()
+        val cacheKey = "autocomplete:$cleanedQuery"
+
+        cacheGateway.getAutoComplete(cacheKey)?.let {
+            return Output(it)
+        }
+
+        val result = University.match(cleanedQuery)
+
+        cacheGateway.setAutoComplete(cacheKey, result)
         return Output(
-            output = University.match(input.query)
+            output = result
         )
+    }
+
+    private fun String.clean(): String {
+        val suffixes = listOf("대학교", "캠퍼스")
+
+        for (suffix in suffixes) {
+            if (this.endsWith(suffix)) {
+                return this.removeSuffix(suffix)
+            }
+        }
+        return this
     }
 }

--- a/application/src/test/kotlin/com/dobby/usecase/member/SearchUniversityAutoCompleteUseCaseTest.kt
+++ b/application/src/test/kotlin/com/dobby/usecase/member/SearchUniversityAutoCompleteUseCaseTest.kt
@@ -1,17 +1,22 @@
 package com.dobby.usecase.member
 
+import com.dobby.gateway.CacheGateway
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
 
 class SearchUniversityAutoCompleteUseCaseTest : BehaviorSpec({
-    val useCase = SearchUniversityAutoCompleteUseCase()
+    val cacheGateway = mockk<CacheGateway>(relaxed = true)
+    val useCase = SearchUniversityAutoCompleteUseCase(cacheGateway)
 
     given("대학 자동완성 검색 유즈케이스가 주어졌을 때") {
 
         `when`("정확한 이름 일부를 입력하면") {
             val input = SearchUniversityAutoCompleteUseCase.Input("서울")
+            every { cacheGateway.getAutoComplete(any()) } returns null
 
             then("해당 키워드를 포함하는 대학교 목록이 반환된다") {
                 val result = useCase.execute(input)
@@ -22,6 +27,7 @@ class SearchUniversityAutoCompleteUseCaseTest : BehaviorSpec({
 
         `when`("초성으로 입력하면") {
             val input = SearchUniversityAutoCompleteUseCase.Input("ㅇㅎㅇㅈㄷㅎㄱ")
+            every { cacheGateway.getAutoComplete(any()) } returns null
 
             then("이화여자대학교가 포함된 결과가 반환된다") {
                 val result = useCase.execute(input)
@@ -32,10 +38,27 @@ class SearchUniversityAutoCompleteUseCaseTest : BehaviorSpec({
 
         `when`("존재하지 않는 키워드를 입력하면") {
             val input = SearchUniversityAutoCompleteUseCase.Input("무무대학교")
+            every { cacheGateway.getAutoComplete(any()) } returns null
 
             then("빈 리스트가 반환된다") {
                 val result = useCase.execute(input)
                 result.output.shouldBeEmpty()
+            }
+        }
+    }
+
+    given("캐시에 값이 있는 경우") {
+        val query = "서울대학교"
+        val cleanedQuery = "서울"
+        val cached = listOf("서울대학교")
+
+        every { cacheGateway.getAutoComplete("autocomplete:$cleanedQuery") } returns cached
+
+        `when`("같은 키워드로 실행하면") {
+            val result = useCase.execute(SearchUniversityAutoCompleteUseCase.Input(query))
+
+            then("캐시된 결과가 반환된다") {
+                result.output shouldBe cached
             }
         }
     }

--- a/domain/src/main/kotlin/com/dobby/enums/University.kt
+++ b/domain/src/main/kotlin/com/dobby/enums/University.kt
@@ -282,23 +282,12 @@ enum class University(
     val initial: String by lazy { extractInitial(displayName) }
 
     companion object {
-        private val suffixes = listOf("대학교", "캠퍼스")
-
-        private fun String.clean(): String {
-            for (suffix in suffixes) {
-                if (this.endsWith(suffix)) {
-                    return this.removeSuffix(suffix)
-                }
-            }
-            return this
-        }
 
         fun match(keyword: String): List<String> {
             return entries.filter {
-                val cleaned = it.displayName.clean()
                 when {
                     keyword.length == 1 -> it.initial.startsWith(keyword)
-                    else -> cleaned.contains(keyword, ignoreCase = true) || it.initial.contains(keyword)
+                    else -> it.displayName.contains(keyword, ignoreCase = true) || it.initial.contains(keyword)
                 }
             }.map { it.displayName }
         }

--- a/domain/src/main/kotlin/com/dobby/gateway/CacheGateway.kt
+++ b/domain/src/main/kotlin/com/dobby/gateway/CacheGateway.kt
@@ -3,9 +3,11 @@ package com.dobby.gateway
 interface CacheGateway {
     fun <T> getObject(key: String, clazz: Class<T>): T?
     fun get(key: String): String?
+    fun getAutoComplete(key: String): List<String>?
     fun setObject(key: String, value: Any)
     fun set(key: String, value: String)
     fun setCode(key: String, value: String)
+    fun setAutoComplete(key: String, value: List<String>)
     fun incrementRequestCount(key: String)
     fun evict(key: String)
 }

--- a/infrastructure/src/main/kotlin/com/dobby/external/gateway/cache/RedisCacheGatewayImpl.kt
+++ b/infrastructure/src/main/kotlin/com/dobby/external/gateway/cache/RedisCacheGatewayImpl.kt
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.springframework.core.env.Environment
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
-import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 @Component
@@ -34,7 +33,7 @@ class RedisCacheGatewayImpl(
 
     override fun getAutoComplete(key: String): List<String>? {
         return get(key)?.let { json ->
-            objectMapper.readValue(json, object: TypeReference<List<String>>() {})
+            objectMapper.readValue(json, object : TypeReference<List<String>>() {})
         }
     }
 

--- a/infrastructure/src/main/kotlin/com/dobby/external/gateway/cache/RedisCacheGatewayImpl.kt
+++ b/infrastructure/src/main/kotlin/com/dobby/external/gateway/cache/RedisCacheGatewayImpl.kt
@@ -1,10 +1,12 @@
 package com.dobby.external.gateway.cache
 
 import com.dobby.gateway.CacheGateway
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.springframework.core.env.Environment
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 @Component
@@ -18,6 +20,7 @@ class RedisCacheGatewayImpl(
     private val cacheTimeout = 240L
     private val codeTimeout = 10L
     private val requestTimeout = 24L
+    private val autoCompleteTimeout = 30L
 
     override fun <T> getObject(key: String, clazz: Class<T>): T? {
         return get(key)?.let { json ->
@@ -27,6 +30,12 @@ class RedisCacheGatewayImpl(
 
     override fun get(key: String): String? {
         return redisTemplate.opsForValue().get(getCacheKey(key))
+    }
+
+    override fun getAutoComplete(key: String): List<String>? {
+        return get(key)?.let { json ->
+            objectMapper.readValue(json, object: TypeReference<List<String>>() {})
+        }
     }
 
     override fun setObject(key: String, value: Any) {
@@ -40,6 +49,12 @@ class RedisCacheGatewayImpl(
 
     override fun setCode(key: String, value: String) {
         redisTemplate.opsForValue().set(getCacheKey(key), value, codeTimeout, TimeUnit.MINUTES)
+    }
+
+    override fun setAutoComplete(key: String, value: List<String>) {
+        val json = objectMapper.writeValueAsString(value)
+        redisTemplate.opsForValue()
+            .set(getCacheKey(key), json, autoCompleteTimeout, TimeUnit.MINUTES)
     }
 
     override fun evict(key: String) {


### PR DESCRIPTION
## 💡 작업 내용
- **TTL이 30분인 캐싱처리로 자동완성 API의 잦은 호출을 방지**하였습니다.
- YS-504의 리팩토링 작업입니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-506

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 대학 자동완성 결과에 대한 캐시 기능이 추가되어, 동일한 검색어 입력 시 더 빠른 결과 제공이 가능합니다.

* **버그 수정**
  * 대학명 자동완성 검색 시 불필요한 접미사(예: "대학교", "캠퍼스")를 제거하여 더 정확한 검색 결과를 제공합니다.

* **테스트**
  * 자동완성 캐시 동작을 검증하는 테스트가 추가되었습니다.

* **기타**
  * 캐시 인터페이스 및 구현체에 자동완성 관련 메서드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-506