### PR TITLE
[YS-534] feat: 공고 키워드 자동완성 일일 사용량 제한 로직 비활성화

### DIFF
--- a/application/src/main/kotlin/com/dobby/usecase/experiment/ExtractExperimentPostKeywordsUseCase.kt
+++ b/application/src/main/kotlin/com/dobby/usecase/experiment/ExtractExperimentPostKeywordsUseCase.kt
@@ -32,7 +32,7 @@ class ExtractExperimentPostKeywordsUseCase(
 
     override fun execute(input: Input): Output {
         val member = memberGateway.getById(input.memberId)
-        validateDailyUsageLimit(input.memberId)
+        // validateDailyUsageLimit(input.memberId)
 
         val experimentPostKeyword = openAiGateway.extractKeywords(input.text)
         val log = ExperimentPostKeywordsLog.newExperimentPostKeywordsLog(

--- a/application/src/test/kotlin/com/dobby/usecase/experiment/ExtractExperimentPostKeywordsUseCaseTest.kt
+++ b/application/src/test/kotlin/com/dobby/usecase/experiment/ExtractExperimentPostKeywordsUseCaseTest.kt
@@ -1,6 +1,5 @@
 package com.dobby.usecase.experiment
 
-import com.dobby.exception.ExperimentPostKeywordsDailyLimitExceededException
 import com.dobby.gateway.OpenAiGateway
 import com.dobby.gateway.experiment.ExperimentPostKeywordsLogGateway
 import com.dobby.gateway.member.MemberGateway
@@ -9,7 +8,6 @@ import com.dobby.model.experiment.keyword.ExperimentPostKeywords
 import com.dobby.model.member.Member
 import com.dobby.util.IdGenerator
 import com.dobby.util.TimeProvider
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -71,30 +69,30 @@ class ExtractExperimentPostKeywordsUseCaseTest : BehaviorSpec({
         }
     }
 
-    given("일일 사용 한도에 도달한 사용자가") {
-        val memberId = "exceeded_member_456"
-        val inputText = "실험 참여자 모집"
-        val input = ExtractExperimentPostKeywordsUseCase.Input(memberId, inputText)
-
-        val mockMember = mockk<Member>()
-        val currentDateTime = LocalDateTime.of(2025, 1, 27, 15, 30, 0)
-
-        every { TimeProvider.currentDateTime() } returns currentDateTime
-        every { memberGateway.getById(memberId) } returns mockMember
-        every {
-            experimentPostKeywordsLogGateway.countByMemberIdAndCreatedAtBetween(
-                memberId = memberId,
-                start = currentDateTime.toLocalDate().atStartOfDay(),
-                end = currentDateTime.toLocalDate().plusDays(1).atStartOfDay()
-            )
-        } returns 2
-
-        `when`("키워드 추출을 요청하면") {
-            then("DailyLimitExceededException 예외가 발생해야 한다") {
-                shouldThrow<ExperimentPostKeywordsDailyLimitExceededException> {
-                    extractExperimentPostKeywordsUseCase.execute(input)
-                }
-            }
-        }
-    }
+//    given("일일 사용 한도에 도달한 사용자가") {
+//        val memberId = "exceeded_member_456"
+//        val inputText = "실험 참여자 모집"
+//        val input = ExtractExperimentPostKeywordsUseCase.Input(memberId, inputText)
+//
+//        val mockMember = mockk<Member>()
+//        val currentDateTime = LocalDateTime.of(2025, 1, 27, 15, 30, 0)
+//
+//        every { TimeProvider.currentDateTime() } returns currentDateTime
+//        every { memberGateway.getById(memberId) } returns mockMember
+//        every {
+//            experimentPostKeywordsLogGateway.countByMemberIdAndCreatedAtBetween(
+//                memberId = memberId,
+//                start = currentDateTime.toLocalDate().atStartOfDay(),
+//                end = currentDateTime.toLocalDate().plusDays(1).atStartOfDay()
+//            )
+//        } returns 2
+//
+//        `when`("키워드 추출을 요청하면") {
+//            then("DailyLimitExceededException 예외가 발생해야 한다") {
+//                shouldThrow<ExperimentPostKeywordsDailyLimitExceededException> {
+//                    extractExperimentPostKeywordsUseCase.execute(input)
+//                }
+//            }
+//        }
+//    }
 })


### PR DESCRIPTION
## 💡 작업 내용
- FE 요청으로 공고 키워드 자동완성 일일 사용량 제한 로직 비활성화

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 주석 처리한 PR이라 바로 머지하겠습니다~


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-534

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 키워드 추출 기능에서 일일 사용량 제한 검증이 비활성화되었습니다.

* **테스트**
  * 일일 사용량 초과 시 예외가 발생하는 테스트가 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->