### PR TITLE
[YS-620] [RELEASE] 릴리즈 1.2.4

### DIFF
--- a/application/src/test/kotlin/com/dobby/usecase/experiment/CreateExperimentPostUseCaseTest.kt
+++ b/application/src/test/kotlin/com/dobby/usecase/experiment/CreateExperimentPostUseCaseTest.kt
@@ -9,6 +9,7 @@ import com.dobby.enums.member.MemberStatus
 import com.dobby.enums.member.ProviderType
 import com.dobby.enums.member.RoleType
 import com.dobby.exception.ExperimentPostInvalidOnlineRequestException
+import com.dobby.exception.ExperimentPostTargetGroupAgeException
 import com.dobby.exception.PermissionDeniedException
 import com.dobby.gateway.experiment.ExperimentPostGateway
 import com.dobby.gateway.member.MemberGateway
@@ -208,6 +209,73 @@ class CreateExperimentPostUseCaseTest : BehaviorSpec({
             then("ExperimentPostInvalidOnlineRequestException 예외가 발생해야 한다") {
                 shouldThrow<ExperimentPostInvalidOnlineRequestException> {
                     createExperimentPostUseCase.execute(invalidInput)
+                }
+            }
+        }
+    }
+
+    given("타겟 그룹의 나이 범위가 유효하지 않은 경우") {
+        val validMember = Member(
+            id = "4",
+            role = RoleType.RESEARCHER,
+            contactEmail = "christer10@naver.com",
+            oauthEmail = "christer10@naver.com",
+            name = "신수정",
+            provider = ProviderType.NAVER,
+            status = MemberStatus.ACTIVE,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+            deletedAt = null
+        )
+
+        fun buildInput(startAge: Int?, endAge: Int?) = CreateExperimentPostUseCase.Input(
+            memberId = "4",
+            targetGroupInfo = CreateExperimentPostUseCase.TargetGroupInfo(
+                startAge = startAge,
+                endAge = endAge,
+                genderType = GenderType.MALE,
+                otherCondition = "야뿌이셨던 남성분"
+            ),
+            applyMethodInfo = CreateExperimentPostUseCase.ApplyMethodInfo(
+                content = "구글폼 보고 참여해주세요 :)",
+                formUrl = "google.form.co.kr",
+                phoneNum = "010-5729-7754"
+            ),
+            imageListInfo = CreateExperimentPostUseCase.ImageListInfo(
+                images = listOf("이미지1")
+            ),
+            startDate = LocalDate.of(2025, 2, 3),
+            endDate = LocalDate.of(2025, 2, 10),
+            matchType = MatchType.OFFLINE,
+            count = 35,
+            timeRequired = TimeSlot.LESS_30M,
+            leadResearcher = "야뿌 랩실 서버 25기 신수정",
+            isOnCampus = true,
+            place = "이화여자대학교",
+            region = Region.SEOUL,
+            area = Area.GEUMCHEONGU,
+            detailedAddress = "ECC B123호",
+            reward = "얍 지각면제권 100장",
+            title = "야뿌 최고 먹짱 실험자 모집합니다",
+            content = "YAPP에서 가장 치킨 잘 먹는 사람",
+            alarmAgree = true
+        )
+
+        every { memberGateway.getById("4") } returns validMember
+        every { idGenerator.generateId() } returns "1"
+
+        `when`("endAge가 startAge보다 작으면") {
+            then("ExperimentPostTargetGroupAgeException 예외가 발생해야 한다") {
+                shouldThrow<ExperimentPostTargetGroupAgeException> {
+                    createExperimentPostUseCase.execute(buildInput(startAge = 30, endAge = 20))
+                }
+            }
+        }
+
+        `when`("startAge가 음수이면") {
+            then("ExperimentPostTargetGroupAgeException 예외가 발생해야 한다") {
+                shouldThrow<ExperimentPostTargetGroupAgeException> {
+                    createExperimentPostUseCase.execute(buildInput(startAge = -1, endAge = 20))
                 }
             }
         }

--- a/domain/src/main/kotlin/com/dobby/exception/DobbyException.kt
+++ b/domain/src/main/kotlin/com/dobby/exception/DobbyException.kt
@@ -69,6 +69,7 @@ data object ExperimentPostContentException : ClientException("EP0011", "Content 
 data object ExperimentPostCountException : ClientException("EP0012", "Count could be more than zero.")
 data object ExperimentPostLeadResearcherException : ClientException("EP0013", "Lead Researcher cannot be null.")
 data object ExperimentPostKeywordsDailyLimitExceededException : ClientException("EP0014", "Daily usage limit for experiment post keywords extraction has been exceeded.")
+data object ExperimentPostTargetGroupAgeException : ClientException("EP0015", "Invalid target group age range: startAge must be >= 0 and endAge must be >= startAge.")
 
 /**
  * ServerException: Exceptions caused by internal server issues

--- a/domain/src/main/kotlin/com/dobby/model/experiment/TargetGroup.kt
+++ b/domain/src/main/kotlin/com/dobby/model/experiment/TargetGroup.kt
@@ -1,6 +1,7 @@
 package com.dobby.model.experiment
 
 import com.dobby.enums.member.GenderType
+import com.dobby.exception.ExperimentPostTargetGroupAgeException
 
 data class TargetGroup(
     val id: String,
@@ -20,6 +21,8 @@ data class TargetGroup(
             return this
         }
 
+        validateAgeRange(startAge, endAge)
+
         return this.copy(
             startAge = startAge,
             endAge = endAge,
@@ -35,12 +38,21 @@ data class TargetGroup(
             endAge: Int?,
             genderType: GenderType,
             otherCondition: String?
-        ) = TargetGroup(
-            id = id,
-            startAge = startAge,
-            endAge = endAge,
-            genderType = genderType,
-            otherCondition = otherCondition
-        )
+        ): TargetGroup {
+            validateAgeRange(startAge, endAge)
+            return TargetGroup(
+                id = id,
+                startAge = startAge,
+                endAge = endAge,
+                genderType = genderType,
+                otherCondition = otherCondition
+            )
+        }
+
+        private fun validateAgeRange(startAge: Int?, endAge: Int?) {
+            if (startAge != null && startAge < 0) throw ExperimentPostTargetGroupAgeException
+            if (endAge != null && endAge < 0) throw ExperimentPostTargetGroupAgeException
+            if (startAge != null && endAge != null && endAge < startAge) throw ExperimentPostTargetGroupAgeException
+        }
     }
 }


### PR DESCRIPTION
Prevents DataIntegrityViolationException from CHK_target_group_age by throwing ExperimentPostTargetGroupAgeException (EP0015) when startAge is negative or endAge is less than startAge.

## 💡 작업 내용
- 작업한 내용을 간략하게 리스트로 적어주세요

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 빌드에 성공했나요?
- [ ] 본인을 assign 해주세요.
- [ ] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 실험 게시글 대상 그룹의 연령 범위를 검증합니다.
  * 시작 연령이 음수이거나 종료 연령이 시작 연령보다 낮은 경우, 유효하지 않은 연령 범위 오류를 표시합니다.
  * 대상 그룹 생성 및 수정 시 동일한 검증 기준이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->